### PR TITLE
Bugfix: bucket position within an existing position is not detected properly

### DIFF
--- a/src/bucket.jl
+++ b/src/bucket.jl
@@ -854,23 +854,29 @@ function _include_new_body_pos!(
             (min_h - tol < out.body[ind][ii, jj]) &&
             (max_h + tol > out.body[ind][ii, jj])
         )
-            ### New position is overlapping with an existing one ###
+            ### New position is overlapping with an existing position ###
             push!(status, 1)
         elseif (
             (min_h - tol < out.body[ind+1][ii, jj]) &&
             (max_h + tol > out.body[ind+1][ii, jj])
         )
-            ### New position is overlapping with an existing one ###
+            ### New position is overlapping with an existing position ###
             push!(status, 1)
+        elseif (
+            (min_h + tol > out.body[ind][ii, jj]) &&
+            (max_h - tol < out.body[ind+1][ii, jj])
+        )
+            ### New position is within an existing position ###
+            return
         else
-            ### New position is not overlapping with the two existing ones ###
+            ### New position is not overlapping with the two existing positions ###
             push!(status, -1)
         end
     end
 
     # Updating the bucket position
     if (status == [1, 1])
-        ### New position is overlapping with the two existing ones ###
+        ### New position is overlapping with the two existing positions ###
         out.body[1][ii, jj] = minimum([out.body[1][ii, jj], out.body[3][ii, jj], min_h])
         out.body[2][ii, jj] = maximum([out.body[2][ii, jj], out.body[4][ii, jj], max_h])
 
@@ -878,11 +884,11 @@ function _include_new_body_pos!(
         out.body[3][ii, jj] = 0.0
         out.body[4][ii, jj] = 0.0
     elseif (status[1] == 1)
-        ### New position is overlapping with an existing one ###
+        ### New position is overlapping with an existing position ###
         out.body[1][ii, jj] = min(out.body[1][ii, jj], min_h)
         out.body[2][ii, jj] = max(out.body[2][ii, jj], max_h)
     elseif (status[2] == 1)
-        ### New position is overlapping with an existing one ###
+        ### New position is overlapping with an existing position ###
         out.body[3][ii, jj] = min(out.body[3][ii, jj], min_h)
         out.body[4][ii, jj] = max(out.body[4][ii, jj], max_h)
     elseif (status[1] == 0)
@@ -894,7 +900,7 @@ function _include_new_body_pos!(
         out.body[3][ii, jj] = min_h
         out.body[4][ii, jj] = max_h
     else
-        ### New position is not overlapping with the two existing ones ###
+        ### New position is not overlapping with the two existing positions ###
         # This should not happen and indicates a problem in the workflow
         throw(ErrorException(
             "Try to update body, but given position does not overlap with two existing ones"

--- a/src/soil_dynamics.jl
+++ b/src/soil_dynamics.jl
@@ -67,4 +67,7 @@ function soil_dynamics!(
 
     # Updating position of soil resting on the bucket
     _update_body_soil!(out, pos, ori, grid, bucket)
+
+    # Moving intersecting soil cells
+    _move_intersecting_cells!(out, grid, tol)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -92,12 +92,18 @@ function _locate_all_non_zeros(
     non_zeros_pos = Vector{Vector{Int64}}()
     # Compiling all positions
     for cell in non_zeros_1
-        if ((sparse_array[1][cell] != 0.0) || (sparse_array[2][cell] != 0.0))
+        if (
+            (sparse_array[1][cell[1], cell[2]] != 0.0) ||
+            (sparse_array[2][cell[1], cell[2]] != 0.0)
+        )
             push!(non_zeros_pos, [1; cell])
         end
     end
     for cell in non_zeros_3
-        if ((sparse_array[3][cell] != 0.0) || (sparse_array[4][cell] != 0.0))
+        if (
+            (sparse_array[3][cell[1], cell[2]] != 0.0) ||
+            (sparse_array[4][cell[1], cell[2]] != 0.0)
+        )
             push!(non_zeros_pos, [3; cell])
         end
     end
@@ -400,10 +406,10 @@ function check_soil(
     end
 
     # Collecting all cells where the bucket soil is located
-    body_pos = _locate_all_non_zeros(out.body_soil)
+    body_soil_pos = _locate_all_non_zeros(out.body_soil)
 
     # Iterating over all cells where the bucket is located
-    for cell in body_pos
+    for cell in body_soil_pos
         ii = cell[2]
         jj = cell[3]
         ind = cell[1]

--- a/test/unit_test/test_bucket.jl
+++ b/test/unit_test/test_bucket.jl
@@ -984,6 +984,26 @@ end
     _include_new_body_pos!(out, 9, 12, 0.6, 0.8)
     @test (out.body[1][9, 12] ≈ 0.5) && (out.body[2][9, 12] ≈ 0.9)
 
+    # Testing to add a position within an existing position (1)
+    _include_new_body_pos!(out, 7, 10, 0.9, 2.5)
+    @test (out.body[1][7, 10] ≈ 0.7) && (out.body[2][7, 10] ≈ 2.5)
+    @test (out.body[3][7, 10] ≈ -0.4) && (out.body[4][7, 10] ≈ 0.6)
+
+    # Testing to add a position within an existing position (2)
+    _include_new_body_pos!(out, 7, 10, -0.4, 0.6)
+    @test (out.body[1][7, 10] ≈ 0.7) && (out.body[2][7, 10] ≈ 2.5)
+    @test (out.body[3][7, 10] ≈ -0.4) && (out.body[4][7, 10] ≈ 0.6)
+
+    # Testing to add a position within an existing position (3)
+    _include_new_body_pos!(out, 6, 6, 0.1, 0.2)
+    @test (out.body[1][6, 6] ≈ 0.1) && (out.body[2][6, 6] ≈ 0.2)
+    @test (out.body[3][6, 6] == 0.0) && (out.body[4][6, 6] == 0.0)
+
+    # Testing to add a position within an existing position (4)
+    _include_new_body_pos!(out, 6, 6, 0.15, 0.18)
+    @test (out.body[1][6, 6] ≈ 0.1) && (out.body[2][6, 6] ≈ 0.2)
+    @test (out.body[3][6, 6] == 0.0) && (out.body[4][6, 6] == 0.0)
+
     # Testing that incorrect request throws an error
     @test_throws ErrorException _include_new_body_pos!(out, 7, 10, 3.0, 3.1)
 


### PR DESCRIPTION
# Description
- Added a case for when a detected bucket layer is within an already existing bucket layer
- Added _move_intersecting_cells! to soil_dynamics
- Fixed indices issue in locate_all_non_zeros
- Updated unit tests
- Improved texts