### PR TITLE
Second iteration on code optimization: add working areas

### DIFF
--- a/src/relax.jl
+++ b/src/relax.jl
@@ -89,10 +89,22 @@ function _relax_terrain!(
     # Storing all possible directions for relaxation
     directions = [[1, 0], [-1, 0], [0, 1], [0, -1]]
 
+    # Initializing the 2D bounding box of the unstable cells
+    relax_min_x = 2 * grid.half_length_x
+    relax_max_x = 0
+    relax_min_y = 2 * grid.half_length_x
+    relax_max_y = 0
+
     # Iterating over all unstable cells
     for cell in unstable_cells
         ii = cell[1]
         jj = cell[2]
+
+        # Updating the 2D bounding box of the unstable cells
+        relax_min_x = minimum(relax_min_x, ii)
+        relax_max_x = maximum(relax_max_x, ii)
+        relax_min_y = minimum(relax_min_y, jj)
+        relax_max_y = maximum(relax_max_y, jj)
 
         # Randomizing direction to avoid asymmetry
         shuffle!(directions)
@@ -122,6 +134,12 @@ function _relax_terrain!(
             )
         end
     end
+
+    # Updating relax_area
+    out.relax_area[1, 1] = max(relax_min_x - sim.cell_buffer, 2)
+    out.relax_area[1, 2] = min(relax_max_x + sim.cell_buffer, 2 * grid.half_length_x)
+    out.relax_area[2, 1] = max(relax_min_y - sim.cell_buffer, 2)
+    out.relax_area[2, 2] = min(relax_max_y + sim.cell_buffer, 2 * grid.half_length_y)
 end
 
 """

--- a/src/relax.jl
+++ b/src/relax.jl
@@ -53,7 +53,7 @@ avalanche on the bucket.
 
 # Example
     grid = GridParam(4.0, 4.0, 3.0, 0.05, 0.01)
-    sim = SimParam(0.85, 3)
+    sim = SimParam(0.85, 3, 4)
     terrain = zeros(2 * grid.half_length_x + 1, 2 * grid.half_length_y + 1)
     out = SimOut(terrain, grid)
 
@@ -165,7 +165,7 @@ This function only moves the soil when the following conditions are met:
 
 # Example
     grid = GridParam(4.0, 4.0, 3.0, 0.05, 0.01)
-    sim = SimParam(0.85, 3)
+    sim = SimParam(0.85, 3, 4)
     terrain = zeros(2 * grid.half_length_x + 1, 2 * grid.half_length_y + 1)
     out = SimOut(terrain, grid)
 

--- a/src/relax.jl
+++ b/src/relax.jl
@@ -101,10 +101,10 @@ function _relax_terrain!(
         jj = cell[2]
 
         # Updating the 2D bounding box of the unstable cells
-        relax_min_x = minimum(relax_min_x, ii)
-        relax_max_x = maximum(relax_max_x, ii)
-        relax_min_y = minimum(relax_min_y, jj)
-        relax_max_y = maximum(relax_max_y, jj)
+        relax_min_x = min(relax_min_x, ii)
+        relax_max_x = max(relax_max_x, ii)
+        relax_min_y = min(relax_min_y, jj)
+        relax_max_y = max(relax_max_y, jj)
 
         # Randomizing direction to avoid asymmetry
         shuffle!(directions)

--- a/src/relax.jl
+++ b/src/relax.jl
@@ -290,8 +290,8 @@ function _locate_unstable_terrain_cell(
     unstable_cells = Vector{Vector{Int64}}()
 
     # Iterating over the terrain
-    for ii in 2:size(out.terrain, 1) - 1
-        for jj in 2:size(out.terrain, 2) - 1
+    for ii in out.impact_area[1, 1]:out.impact_area[1, 2]
+        for jj in out.impact_area[2, 1]:out.impact_area[2, 2]
             # Calculating the minimum height allowed surrounding the considered soil cell
             h_min = out.terrain[ii, jj] - dh_max - tol
 

--- a/src/soil_dynamics.jl
+++ b/src/soil_dynamics.jl
@@ -48,7 +48,7 @@ to reach a state closer to equilibrium.
     b = [0.0, 0.0, -0.5]
     t = [1.0, 0.0, -0.5]
     bucket = BucketParam(o, j, b, t, 0.5)
-    sim = SimParam(0.85, 3)
+    sim = SimParam(0.85, 3, 4)
     terrain = zeros(2 * grid.half_length_x + 1, 2 * grid.half_length_y + 1)
     out = SimOut(terrain, grid)
 

--- a/src/soil_dynamics.jl
+++ b/src/soil_dynamics.jl
@@ -85,6 +85,12 @@ function soil_dynamics!(
     while (!out.equilibrium[1] && it < sim.max_iterations)
         it += 1
 
+        # Updating impact_area
+        out.impact_area[1, 1] = min(out.bucket_area[1, 1], out.relax_area[1, 1])
+        out.impact_area[2, 1] = min(out.bucket_area[2, 1], out.relax_area[2, 1])
+        out.impact_area[1, 2] = max(out.bucket_area[1, 2], out.relax_area[1, 2])
+        out.impact_area[2, 2] = max(out.bucket_area[2, 2], out.relax_area[2, 2])
+
         # Relaxing the terrain
         _relax_terrain!(out, grid, sim, tol)
 

--- a/src/soil_dynamics.jl
+++ b/src/soil_dynamics.jl
@@ -69,7 +69,7 @@ function soil_dynamics!(
     end
 
     # Updating bucket position
-    _calc_bucket_pos!(out, pos, ori, grid, bucket, 0.5, tol)
+    _calc_bucket_pos!(out, pos, ori, grid, bucket, sim, 0.5, tol)
 
     # Updating position of soil resting on the bucket
     _update_body_soil!(out, pos, ori, grid, bucket, tol)

--- a/src/types.jl
+++ b/src/types.jl
@@ -316,7 +316,7 @@ Requirements:
 - The `repose_angle` should be between 0.0 and pi / 2. The upper limit may be extended in
   the future.
 - The `max_iterations` should be greater or equal to zero.
-- The `cell_buffer` should be greater or equal to zero.
+- The `cell_buffer` should be greater or equal to 2.
 
 # Example
 
@@ -342,9 +342,9 @@ struct SimParam{I<:Int64,T<:Float64}
             throw(DomainError(max_iterations, "max_iterations should be greater or equal" *
             " to zero"))
         end
-        if ((cell_buffer < 0.0) && (cell_buffer != 0.0))
-            throw(DomainError(max_iterations, "cell_buffer should be greater or equal to" *
-            " zero"))
+        if ((cell_buffer < 2.0) && (cell_buffer != 2.0))
+            @warn "cell_buffer too low, setting to 2"
+            cell_buffer = 2
         end
 
         new{I,T}(repose_angle, max_iterations, cell_buffer)

--- a/src/types.jl
+++ b/src/types.jl
@@ -301,11 +301,13 @@ Store all parameters related to the simulation.
 # Fields
 - `repose_angle::Float64`: The repose angle of the considered soil. [rad]
 - `max_iterations::Int64`: The maximum number of relaxation iterations per step.
+- `cell_buffer::Int64`: The number of buffer cells surrounding the bucket and the relaxed
+                        terrain where soil equilibrium is checked.
 
 # Inner constructor
 
     SimParam(
-        repose_angle::T, max_iterations::I
+        repose_angle::T, max_iterations::I, cell_buffer::I,
     ) where {I<:Int64,T<:Float64}
 
 Create a new instance of `SimParam`.
@@ -314,17 +316,20 @@ Requirements:
 - The `repose_angle` should be between 0.0 and pi / 2. The upper limit may be extended in
   the future.
 - The `max_iterations` should be greater or equal to zero.
+- The `cell_buffer` should be greater or equal to zero.
 
 # Example
 
-    sim = SimParam(0.85, 3)
+    sim = SimParam(0.85, 3, 4)
 """
 struct SimParam{I<:Int64,T<:Float64}
     repose_angle::T
     max_iterations::I
+    cell_buffer::I
     function SimParam(
         repose_angle::T,
         max_iterations::I
+        cell_buffer::I
     ) where {I<:Int64,T<:Float64}
 
         if (
@@ -337,8 +342,12 @@ struct SimParam{I<:Int64,T<:Float64}
             throw(DomainError(max_iterations, "max_iterations should be greater or equal" *
             " to zero"))
         end
+        if ((cell_buffer < 0.0) && (cell_buffer != 0.0))
+            throw(DomainError(max_iterations, "cell_buffer should be greater or equal to" *
+            " zero"))
+        end
 
-        new{I,T}(repose_angle, max_iterations)
+        new{I,T}(repose_angle, max_iterations, cell_buffer)
     end
 end
 
@@ -413,6 +422,7 @@ struct SimOut{B<:Bool,I<:Int64,T<:Float64}
     body::Vector{SparseMatrixCSC{T,I}}
     body_soil::Vector{SparseMatrixCSC{T,I}}
     body_soil_pos::Vector{Vector{I}}
+
     function SimOut(
         terrain::Matrix{T},
         grid::GridParam{I,T}

--- a/src/types.jl
+++ b/src/types.jl
@@ -328,7 +328,7 @@ struct SimParam{I<:Int64,T<:Float64}
     cell_buffer::I
     function SimParam(
         repose_angle::T,
-        max_iterations::I
+        max_iterations::I,
         cell_buffer::I
     ) where {I<:Int64,T<:Float64}
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -376,6 +376,10 @@ Store all outputs of the simulation.
   3-elements vectors. The first element corresponds to the index of the sparse Matrix where
   the minimum height of the soil is stored, while the second and third element correspond to
   the index of the X and Y position, respectively.
+- The active areas (`bucket_area`, `relax_area` and `impact_area`) are assumed to be
+  rectangular and to follow the grid geometry. They are thus stored as 2x2 Matrices where:
+  [1, 1] corresponds to the minimum X index. [1, 2] corresponds to the maximum X index.
+  [2, 1] corresponds to the minimum Y index. [2, 2] corresponds to the maximum Y index.
 
 # Note
 - Currently, only one bucket at a time is supported, but this restriction may be
@@ -395,6 +399,14 @@ Store all outputs of the simulation.
                                                        each XY position. [m]
 - `body_soil_pos::Vector{Vector{Int64}}`: Store the indices of locations where there is
                                           soil resting on the bucket.
+- `bucket_area::Matrix{Int64}`: Store the 2D bounding box of the bucket with a buffer
+                                determined by the parameter `cell_buffer` of `SimParam`.
+- `relax_area::Matrix{Int64}`: Store the 2D bounding box of the area where soil has been
+                               relaxed with a buffer determined by the parameter
+                               `cell_buffer` of `SimParam`.
+- `impact_area::Matrix{Int64}`: Store the union of `bucket_area` and `relax_area`. It
+                                corresponds to the area where the soil equilibrium is
+                                checked.
 
 # Inner constructor
 
@@ -422,7 +434,9 @@ struct SimOut{B<:Bool,I<:Int64,T<:Float64}
     body::Vector{SparseMatrixCSC{T,I}}
     body_soil::Vector{SparseMatrixCSC{T,I}}
     body_soil_pos::Vector{Vector{I}}
-
+    bucket_area::Matrix{Int64}
+    relax_area::Matrix{Int64}
+    impact_area::Matrix{Int64}
     function SimOut(
         terrain::Matrix{T},
         grid::GridParam{I,T}
@@ -456,6 +470,14 @@ struct SimOut{B<:Bool,I<:Int64,T<:Float64}
         # Initalizing body_soil_pos
         body_soil_pos = Vector{Vector{I}}()
 
-        new{Bool,I,T}([false], terrain, body, body_soil, body_soil_pos)
+        # Initalizing active areas
+        bucket_area = zeros(Int64, 2, 2)
+        relax_area = zeros(Int64, 2, 2)
+        impact_area = zeros(Int64, 2, 2)
+
+        new{Bool,I,T}(
+            [false], terrain, body, body_soil, body_soil_pos, bucket_area, relax_area,
+            impact_area
+        )
     end
 end

--- a/test/benchmark/benchmark_body_soil.jl
+++ b/test/benchmark/benchmark_body_soil.jl
@@ -22,6 +22,12 @@ t_pos_init = Vector{Float64}([0.7, 0.0, -0.5])
 bucket_width = 0.5
 bucket = BucketParam(o_pos_init, j_pos_init, b_pos_init, t_pos_init, bucket_width)
 
+# Simulation properties
+repose_angle = 0.85
+max_iterations = 3
+cell_buffer = 4
+sim = SimParam(repose_angle, max_iterations, cell_buffer)
+
 # Terrain properties
 terrain = zeros(2 * grid.half_length_x + 1, 2 * grid.half_length_y + 1)
 out = SimOut(terrain, grid)
@@ -41,7 +47,7 @@ BenchmarkTools.DEFAULT_PARAMETERS.samples = 100
 # Benchmarking for _update_body_soil! function
 pos_1 = [0.5, 0.0, 0.0]
 ori_1 = angle_to_quat(0.0, 0.0, pi / 2, :ZYX)
-_calc_bucket_pos!(out, pos_1, ori_1, grid, bucket)
+_calc_bucket_pos!(out, pos_1, ori_1, grid, bucket, sim)
 out.body_soil[1][91:105, 71] .= out.body[2][91:105, 71]
 out.body_soil[2][91:105, 71] .= out.body[2][91:105, 71] .+ 0.2
 out.body_soil[1][91:104, 72] .= out.body[2][91:104, 72]
@@ -65,7 +71,7 @@ out.body_soil[2][91:93, 80] .= out.body[2][91:93, 80] .+ 0.2
 out.body_soil[1][91:92, 81] .= out.body[2][91:92, 81]
 out.body_soil[2][91:92, 81] .= out.body[2][91:92, 81] .+ 0.2
 pos_2 = [0.5 + cell_size_xy, 0.0, 0.0]
-_calc_bucket_pos!(out, pos_2, ori_1, grid, bucket)
+_calc_bucket_pos!(out, pos_2, ori_1, grid, bucket, sim)
 println("_update_body_soil!")
 display(
     @benchmark _update_body_soil!(out, pos_2, ori_1, grid, bucket)

--- a/test/benchmark/benchmark_bucket.jl
+++ b/test/benchmark/benchmark_bucket.jl
@@ -22,6 +22,12 @@ t_pos_init = Vector{Float64}([0.7, 0.0, -0.5])
 bucket_width = 0.5
 bucket = BucketParam(o_pos_init, j_pos_init, b_pos_init, t_pos_init, bucket_width)
 
+# Simulation properties
+repose_angle = 0.85
+max_iterations = 3
+cell_buffer = 4
+sim = SimParam(repose_angle, max_iterations, cell_buffer)
+
 # Terrain properties
 terrain = zeros(2 * grid.half_length_x + 1, 2 * grid.half_length_y + 1)
 out = SimOut(terrain, grid)
@@ -43,7 +49,7 @@ ori = angle_to_quat(0.0, -pi / 2, 0.0, :ZYX)
 pos = Vector{Float64}([0.0, 0.0, -0.1])
 println("_calc_bucket_pos!")
 display(
-    @benchmark _calc_bucket_pos!(out, pos, ori, grid, bucket)
+    @benchmark _calc_bucket_pos!(out, pos, ori, grid, bucket, sim)
 )
 println("")
 

--- a/test/benchmark/benchmark_intersecting_cells.jl
+++ b/test/benchmark/benchmark_intersecting_cells.jl
@@ -22,6 +22,12 @@ t_pos_init = Vector{Float64}([0.7, 0.0, -0.5])
 bucket_width = 0.5
 bucket = BucketParam(o_pos_init, j_pos_init, b_pos_init, t_pos_init, bucket_width)
 
+# Simulation properties
+repose_angle = 0.85
+max_iterations = 3
+cell_buffer = 4
+sim = SimParam(repose_angle, max_iterations, cell_buffer)
+
 # Terrain properties
 terrain = zeros(2 * grid.half_length_x + 1, 2 * grid.half_length_y + 1)
 out = SimOut(terrain, grid)
@@ -42,7 +48,7 @@ BenchmarkTools.DEFAULT_PARAMETERS.samples = 100
 out.terrain[:, :] .= 0.0
 pos_1 = [0.0, 0.0, 0.0]
 ori_1 = angle_to_quat(0.0, 0.0, pi / 2, :ZYX)
-_calc_bucket_pos!(out, pos_1, ori_1, grid, bucket)
+_calc_bucket_pos!(out, pos_1, ori_1, grid, bucket, sim)
 println("_move_intersecting_cells!")
 display(
     @benchmark _move_intersecting_cells!(out, grid)
@@ -53,7 +59,7 @@ println("")
 out.terrain[:, :] .= 0.0
 pos_1 = [0.0, 0.0, 0.0]
 ori_1 = angle_to_quat(0.0, 0.0, pi / 2, :ZYX)
-_calc_bucket_pos!(out, pos_1, ori_1, grid, bucket)
+_calc_bucket_pos!(out, pos_1, ori_1, grid, bucket, sim)
 println("_move_intersecting_body!")
 display(
     @benchmark _move_intersecting_body!(out, grid)
@@ -85,7 +91,7 @@ println("")
 out.terrain[:, :] .= 0.0
 pos_1 = [0.0, 0.0, 0.0]
 ori_1 = angle_to_quat(0.0, 0.0, pi / 2, :ZYX)
-_calc_bucket_pos!(out, pos_1, ori_1, grid, bucket)
+_calc_bucket_pos!(out, pos_1, ori_1, grid, bucket, sim)
 println("_locate_intersecting_cells")
 display(
     @benchmark intersecting_cells = _locate_intersecting_cells(out)

--- a/test/benchmark/benchmark_relax.jl
+++ b/test/benchmark/benchmark_relax.jl
@@ -41,6 +41,8 @@ out.terrain[50:65, 50:65] .= 0.4
 out.body[1][49, 50:65] .= 0.0
 out.body[2][49, 50:60] .= 0.1
 out.body[2][49, 61:65] .= 0.4
+out.relax_area[:, :] .= Int64[[45, 46] [69, 69]]
+out.impact_area[:, :] .= Int64[[45, 46] [69, 69]]
 println("_relax_terrain!")
 display(
     @benchmark _relax_terrain!(out, grid, sim)

--- a/test/benchmark/benchmark_relax.jl
+++ b/test/benchmark/benchmark_relax.jl
@@ -17,7 +17,8 @@ grid = GridParam(grid_size_x, grid_size_y, grid_size_z, cell_size_xy, cell_size_
 # Simulation properties
 repose_angle = 0.85
 max_iterations = 3
-sim = SimParam(repose_angle, max_iterations)
+cell_buffer = 4
+sim = SimParam(repose_angle, max_iterations, cell_buffer)
 
 # Terrain properties
 terrain = zeros(2 * grid.half_length_x + 1, 2 * grid.half_length_y + 1)

--- a/test/benchmark/benchmark_soil_dynamics.jl
+++ b/test/benchmark/benchmark_soil_dynamics.jl
@@ -47,6 +47,7 @@ BenchmarkTools.DEFAULT_PARAMETERS.samples = 100
 # Benchmarking for soil_dynamics! function
 ori = angle_to_quat(0.0, -pi / 2, 0.0, :ZYX)
 pos = Vector{Float64}([0.0, 0.0, -0.1])
+out.relax_area[:, :] .= Int64[[67, 72] [85, 90]]
 println("soil_dynamics!")
 display(
     @benchmark soil_dynamics!(out, pos, ori, grid, bucket, sim)

--- a/test/benchmark/benchmark_soil_dynamics.jl
+++ b/test/benchmark/benchmark_soil_dynamics.jl
@@ -25,7 +25,8 @@ bucket = BucketParam(o_pos_init, j_pos_init, b_pos_init, t_pos_init, bucket_widt
 # Simulation properties
 repose_angle = 0.85
 max_iterations = 10
-sim = SimParam(repose_angle, max_iterations)
+cell_buffer = 4
+sim = SimParam(repose_angle, max_iterations, cell_buffer)
 
 # Terrain properties
 terrain = zeros(2 * grid.half_length_x + 1, 2 * grid.half_length_y + 1)

--- a/test/benchmark/benchmark_soil_evolution.jl
+++ b/test/benchmark/benchmark_soil_evolution.jl
@@ -20,4 +20,5 @@ println("soil_evolution")
 display(
     @benchmark soil_evolution(false, false, false, false, true)
 )
+disable_logging(Logging.Debug)
 println("")

--- a/test/benchmark/benchmark_utils.jl
+++ b/test/benchmark/benchmark_utils.jl
@@ -22,6 +22,12 @@ t_pos_init = Vector{Float64}([0.7, 0.0, -0.5])
 bucket_width = 0.5
 bucket = BucketParam(o_pos_init, j_pos_init, b_pos_init, t_pos_init, bucket_width)
 
+# Simulation properties
+repose_angle = 0.85
+max_iterations = 3
+cell_buffer = 4
+sim = SimParam(repose_angle, max_iterations, cell_buffer)
+
 # Terrain properties
 terrain = zeros(2 * grid.half_length_x + 1, 2 * grid.half_length_y + 1)
 out = SimOut(terrain, grid)
@@ -41,7 +47,7 @@ BenchmarkTools.DEFAULT_PARAMETERS.samples = 100
 # Benchmarking for _init_sparse_array! function
 ori = angle_to_quat(0.0, -pi / 2, 0.0, :ZYX)
 pos = Vector{Float64}([0.0, 0.0, -0.1])
-_calc_bucket_pos!(out, pos, ori, grid, bucket)
+_calc_bucket_pos!(out, pos, ori, grid, bucket, sim)
 println("_init_sparse_array!")
 display(
     @benchmark _init_sparse_array!(out.body, grid)

--- a/test/example/soil_evolution.jl
+++ b/test/example/soil_evolution.jl
@@ -168,6 +168,9 @@ function soil_evolution(
     dt_i = dt
     time = dt
 
+    # Initializing relax_area as the full grid
+    out.relax_area[:, :] .= Int64[[2, 2] [2 * grid.half_length_x, 2 * grid.half_length_y]]
+
     # Creating time evolution
     while (time + dt_i < total_time)
        # Adding time to time vector

--- a/test/example/soil_evolution.jl
+++ b/test/example/soil_evolution.jl
@@ -88,9 +88,10 @@ function soil_evolution(
     # Initializing the simulation properties
     repose_angle = 0.85
     max_iterations = 10
+    cell_buffer = 4
 
     # SimParam struct
-    sim = SimParam(repose_angle, max_iterations)
+    sim = SimParam(repose_angle, max_iterations, cell_buffer)
 
     # Initializing terrain array to zero height
     terrain = zeros(2 * grid.half_length_x + 1, 2 * grid.half_length_y + 1)

--- a/test/unit_test/test_bucket.jl
+++ b/test/unit_test/test_bucket.jl
@@ -22,6 +22,12 @@ t_pos_init = Vector{Float64}([0.7, 0.0, -0.5])
 bucket_width = 0.5
 bucket = BucketParam(o_pos_init, j_pos_init, b_pos_init, t_pos_init, bucket_width)
 
+# Simulation properties
+repose_angle = 0.785
+max_iterations = 3
+cell_buffer = 4
+sim = SimParam(repose_angle, max_iterations, cell_buffer)
+
 # Terrain properties
 terrain = zeros(2 * grid.half_length_x + 1, 2 * grid.half_length_y + 1)
 out = SimOut(terrain, grid)
@@ -1137,7 +1143,7 @@ end
     pos = Vector{Float64}([0.0, 0.0, 0.0])
 
     # Testing for a bucket in the XZ plane
-    _calc_bucket_pos!(out, pos, ori, grid, bucket)
+    _calc_bucket_pos!(out, pos, ori, grid, bucket, sim)
     # Checking the bucket position
     @test (out.body[1][11, 11] ≈ -0.3) && (out.body[2][11, 11] ≈ 0.3)
     @test (out.body[1][12, 11] ≈ -0.3) && (out.body[2][12, 11] ≈ 0.3)
@@ -1145,6 +1151,8 @@ end
     @test (out.body[1][14, 11] ≈ -0.3) && (out.body[2][14, 11] ≈ 0.3)
     @test (out.body[1][15, 11] ≈ -0.3) && (out.body[2][15, 11] ≈ 0.3)
     @test (out.body[1][16, 11] ≈ -0.3) && (out.body[2][16, 11] ≈ 0.3)
+    @test (out.bucket_area[1, 1] == 7) && (out.bucket_area[1, 2] == 20)
+    @test (out.bucket_area[2, 1] == 7) && (out.bucket_area[2, 2] == 15)
     # Resetting the bucket position
     out.body[1][11:16, 11] .= 0.0
     out.body[2][11:16, 11] .= 0.0
@@ -1164,10 +1172,12 @@ end
     pos = Vector{Float64}([0.0, 0.0, 0.0])
 
     # Testing for a bucket in the XY plane
-    _calc_bucket_pos!(out, pos, ori, grid, bucket)
+    _calc_bucket_pos!(out, pos, ori, grid, bucket, sim)
     # Checking the bucket position
     @test all(out.body[1][11:16, 9:13] .≈ -0.1)
     @test all(out.body[2][11:16, 9:13] .≈ 0.0)
+    @test (out.bucket_area[1, 1] == 7) && (out.bucket_area[1, 2] == 20)
+    @test (out.bucket_area[2, 1] == 5) && (out.bucket_area[2, 2] == 17)
     # Resetting the bucket position
     out.body[1][11:16, 9:13] .= 0.0
     dropzeros!(out.body[1])
@@ -1186,7 +1196,7 @@ end
     pos = Vector{Float64}([0.0, 0.0, -0.1])
 
     # Testing for a bucket in a dummy position
-    _calc_bucket_pos!(out, pos, ori, grid, bucket)
+    _calc_bucket_pos!(out, pos, ori, grid, bucket, sim)
     # Checking the bucket position
     @test all(out.body[1][6, 9:13] .≈ -0.6)
     @test all(out.body[2][6, 9:13] .≈ -0.1)
@@ -1204,6 +1214,8 @@ end
     @test all(out.body[2][10, 9:13] .≈ -0.1)
     @test all(out.body[1][11, 9:13] .≈ -0.2)
     @test all(out.body[2][11, 9:13] .≈ -0.1)
+    @test (out.bucket_area[1, 1] == 2) && (out.bucket_area[1, 2] == 15)
+    @test (out.bucket_area[2, 1] == 5) && (out.bucket_area[2, 2] == 17)
     # Resetting the bucket position
     out.body[1][6:11, 9:13] .= 0.0
     out.body[2][6:11, 9:13] .= 0.0

--- a/test/unit_test/test_relax.jl
+++ b/test/unit_test/test_relax.jl
@@ -1290,39 +1290,47 @@ end
     # Testing the case where there is no bucket and soil is unstable
     set_RNG_seed!(1234)
     out.terrain[10, 15] = -0.2
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] ≈ -0.1) && (out.terrain[9, 15] ≈ -0.1)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[9, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there is the first bucket layer and it has space under it
     set_RNG_seed!(1234)
     out.terrain[10, 15] = -0.2
     out.body[1][10, 15] = -0.1
     out.body[2][10, 15] = 0.0
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] ≈ -0.1) && (out.terrain[9, 15] ≈ -0.1)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[9, 15] = 0.0
     out.body[1][10, 15] = 0.0
     out.body[2][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there is the first bucket layer and soil should avalanche on it
     set_RNG_seed!(1234)
     out.terrain[10, 15] = -0.4
     out.body[1][10, 15] = -0.4
     out.body[2][10, 15] = -0.2
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] ≈ -0.4) && (out.terrain[9, 15] ≈ -0.1)
     @test (out.body_soil[1][10, 15] == -0.2) && (out.body_soil[2][10, 15] ≈ -0.1)
     @test (out.body_soil[3][10, 15] == 0.0) && (out.body_soil[4][10, 15] == 0.0)
     @test (out.body_soil_pos == [[1; 10; 15]])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[9, 15] = 0.0
@@ -1331,6 +1339,7 @@ end
     out.body_soil[1][10, 15] = 0.0
     out.body_soil[2][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there is the first bucket layer and it is high enough to
     # prevent the soil from avalanching
@@ -1338,6 +1347,7 @@ end
     out.terrain[10, 15] = -0.4
     out.body[1][10, 15] = -0.4
     out.body[2][10, 15] = 0.0
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] == -0.4) && (out.terrain[9, 15] == 0.0)
     @test (out.terrain[10, 14] == 0.0) && (out.terrain[10, 16] == 0.0)
@@ -1345,12 +1355,14 @@ end
     @test (out.body_soil[1][10, 15] == 0.0) && (out.body_soil[2][10, 15] == 0.0)
     @test (out.body_soil[3][10, 15] == 0.0) && (out.body_soil[4][10, 15] == 0.0)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[9, 15] = 0.0
     out.body[1][10, 15] = 0.0
     out.body[2][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there is the first bucket layer with bucket soil and it has
     # space under it
@@ -1360,11 +1372,13 @@ end
     out.body[2][10, 15] = -0.5
     out.body_soil[1][10, 15] = -0.5
     out.body_soil[2][10, 15] = 0.0
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] ≈ -0.7) && (out.terrain[9, 15] ≈ -0.1)
     @test (out.body_soil[1][10, 15] == -0.5) && (out.body_soil[2][10, 15] == 0.0)
     @test (out.body_soil[3][10, 15] == 0.0) && (out.body_soil[4][10, 15] == 0.0)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[9, 15] = 0.0
@@ -1373,6 +1387,7 @@ end
     out.body_soil[1][10, 15] = 0.0
     out.body_soil[2][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there is the first bucket layer with bucket soil and soil
     # should avalanche on it
@@ -1382,12 +1397,14 @@ end
     out.body[2][10, 15] = -0.5
     out.body_soil[1][10, 15] = -0.5
     out.body_soil[2][10, 15] = -0.3
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] == -0.8) && (out.terrain[9, 15] ≈ -0.1)
     @test (out.terrain[10, 14] ≈ -0.1)
     @test (out.body_soil[1][10, 15] == -0.5) && (out.body_soil[2][10, 15] ≈ -0.1)
     @test (out.body_soil[3][10, 15] == 0.0) && (out.body_soil[4][10, 15] == 0.0)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[10, 14] = 0.0
@@ -1397,6 +1414,7 @@ end
     out.body_soil[1][10, 15] = 0.0
     out.body_soil[2][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there is the first bucket layer with bucket soil and it is high
     # enough to prevent the soil from avalanching
@@ -1406,6 +1424,7 @@ end
     out.body[2][10, 15] = -0.5
     out.body_soil[1][10, 15] = -0.5
     out.body_soil[2][10, 15] = 0.0
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] == -0.8) && (out.terrain[9, 15] == 0.0)
     @test (out.terrain[10, 14] == 0.0) && (out.terrain[10, 16] == 0.0)
@@ -1413,6 +1432,7 @@ end
     @test (out.body_soil[1][10, 15] == -0.5) && (out.body_soil[2][10, 15] == 0.0)
     @test (out.body_soil[3][10, 15] == 0.0) && (out.body_soil[4][10, 15] == 0.0)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.body[1][10, 15] = 0.0
@@ -1420,21 +1440,25 @@ end
     out.body_soil[1][10, 15] = 0.0
     out.body_soil[2][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there is the second bucket layer and it has space under it
     set_RNG_seed!(1234)
     out.terrain[10, 15] = -0.2
     out.body[3][10, 15] = -0.1
     out.body[4][10, 15] = 0.0
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] ≈ -0.1) && (out.terrain[9, 15] ≈ -0.1)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[9, 15] = 0.0
     out.body[3][10, 15] = 0.0
     out.body[4][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there is the second bucket layer and soil should avalanche on
     # it
@@ -1442,11 +1466,13 @@ end
     out.terrain[10, 15] = -0.4
     out.body[3][10, 15] = -0.4
     out.body[4][10, 15] = -0.2
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] == -0.4) && (out.terrain[9, 15] ≈ -0.1)
     @test (out.body_soil[1][10, 15] == 0.0) && (out.body_soil[2][10, 15] == 0.0)
     @test (out.body_soil[3][10, 15] ≈ -0.2) && (out.body_soil[4][10, 15] ≈ -0.1)
     @test (out.body_soil_pos == [[3; 10; 15]])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[9, 15] = 0.0
@@ -1455,6 +1481,7 @@ end
     out.body_soil[3][10, 15] = 0.0
     out.body_soil[4][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there is the second bucket layer and it is high enough to
     # prevent the soil from avalanching
@@ -1462,16 +1489,19 @@ end
     out.terrain[10, 15] = -0.4
     out.body[3][10, 15] = -0.4
     out.body[4][10, 15] = 0.0
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] == -0.4) && (out.terrain[9, 15] == 0.0)
     @test (out.terrain[10, 14] == 0.0) && (out.terrain[10, 16] == 0.0)
     @test (out.terrain[11, 15] == 0.0)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.body[3][10, 15] = 0.0
     out.body[4][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there is the second bucket layer with bucket soil and it has
     # space under it
@@ -1481,11 +1511,13 @@ end
     out.body[4][10, 15] = -0.5
     out.body_soil[3][10, 15] = -0.5
     out.body_soil[4][10, 15] = -0.1
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] ≈ -0.7) && (out.terrain[9, 15] ≈ -0.1)
     @test (out.body_soil[1][10, 15] == 0.0) && (out.body_soil[2][10, 15] == 0.0)
     @test (out.body_soil[3][10, 15] == -0.5) && (out.body_soil[4][10, 15] == -0.1)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[9, 15] = 0.0
@@ -1494,6 +1526,7 @@ end
     out.body_soil[3][10, 15] = 0.0
     out.body_soil[4][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there is the second bucket layer with bucket soil and soil
     # should avalanche on it
@@ -1503,11 +1536,13 @@ end
     out.body[4][10, 15] = -0.5
     out.body_soil[3][10, 15] = -0.5
     out.body_soil[4][10, 15] = -0.2
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] == -0.8) && (out.terrain[9, 15] ≈ -0.1)
     @test (out.body_soil[1][10, 15] == 0.0) && (out.body_soil[2][10, 15] == 0.0)
     @test (out.body_soil[3][10, 15] == -0.5) && (out.body_soil[4][10, 15] ≈ -0.1)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[9, 15] = 0.0
@@ -1516,6 +1551,7 @@ end
     out.body_soil[3][10, 15] = 0.0
     out.body_soil[4][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there is the second bucket layer with bucket soil and it is
     # high enough to prevent the soil from avalanching
@@ -1525,6 +1561,7 @@ end
     out.body[4][10, 15] = -0.5
     out.body_soil[3][10, 15] = -0.5
     out.body_soil[4][10, 15] = 0.0
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] == -0.8) && (out.terrain[9, 15] == 0.0)
     @test (out.terrain[10, 14] == 0.0) && (out.terrain[10, 16] == 0.0)
@@ -1532,6 +1569,7 @@ end
     @test (out.body_soil[1][10, 15] == 0.0) && (out.body_soil[2][10, 15] == 0.0)
     @test (out.body_soil[3][10, 15] == -0.5) && (out.body_soil[4][10, 15] == 0.0)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.body[3][10, 15] = 0.0
@@ -1539,6 +1577,7 @@ end
     out.body_soil[3][10, 15] = 0.0
     out.body_soil[4][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there are two bucket layers, the first layer being lower and it
     # has space under it
@@ -1548,11 +1587,13 @@ end
     out.body[2][10, 15] = -0.6
     out.body[3][10, 15] = -0.4
     out.body[4][10, 15] = -0.1
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] ≈ -0.7) && (out.terrain[9, 15] ≈ -0.1)
     @test (out.body_soil[1][10, 15] == 0.0) && (out.body_soil[2][10, 15] == 0.0)
     @test (out.body_soil[3][10, 15] == 0.0) && (out.body_soil[4][10, 15] == 0.0)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[9, 15] = 0.0
@@ -1561,6 +1602,7 @@ end
     out.body[3][10, 15] = 0.0
     out.body[4][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there are two bucket layers, the first layer being lower, and
     # soil should avalanche on the second bucket layer
@@ -1570,11 +1612,13 @@ end
     out.body[2][10, 15] = -0.6
     out.body[3][10, 15] = -0.4
     out.body[4][10, 15] = -0.2
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] == -0.8) && (out.terrain[9, 15] ≈ -0.1)
     @test (out.body_soil[1][10, 15] == 0.0) && (out.body_soil[2][10, 15] == 0.0)
     @test (out.body_soil[3][10, 15] ≈ -0.2) && (out.body_soil[4][10, 15] ≈ -0.1)
     @test (out.body_soil_pos == [[3; 10; 15]])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[9, 15] = 0.0
@@ -1585,6 +1629,7 @@ end
     out.body_soil[3][10, 15] = 0.0
     out.body_soil[4][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there are two bucket layers, the first layer being lower, and
     # the second bucket layer is high enough to prevent the soil from avalanching
@@ -1594,6 +1639,7 @@ end
     out.body[2][10, 15] = -0.6
     out.body[3][10, 15] = -0.4
     out.body[4][10, 15] = 0.0
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] == -0.8) && (out.terrain[9, 15] == 0.0)
     @test (out.terrain[10, 14] == 0.0) && (out.terrain[10, 16] == 0.0)
@@ -1601,6 +1647,7 @@ end
     @test (out.body_soil[1][10, 15] == 0.0) && (out.body_soil[2][10, 15] == 0.0)
     @test (out.body_soil[3][10, 15] == 0.0) && (out.body_soil[4][10, 15] == 0.0)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.body[1][10, 15] = 0.0
@@ -1608,6 +1655,7 @@ end
     out.body[3][10, 15] = 0.0
     out.body[4][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there are two bucket layers, the first layer with bucket soil
     # being lower and has space under it
@@ -1619,11 +1667,13 @@ end
     out.body[4][10, 15] = -0.1
     out.body_soil[1][10, 15] = -0.6
     out.body_soil[2][10, 15] = -0.5
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] ≈ -0.7) && (out.terrain[9, 15] ≈ -0.1)
     @test (out.body_soil[1][10, 15] == -0.6) && (out.body_soil[2][10, 15] == -0.5)
     @test (out.body_soil[3][10, 15] == 0.0) && (out.body_soil[4][10, 15] == 0.0)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[9, 15] = 0.0
@@ -1634,6 +1684,7 @@ end
     out.body_soil[1][10, 15] = 0.0
     out.body_soil[2][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there are two bucket layers, the first layer with bucket soil
     # being lower, and soil should avalanche on the second bucket layer
@@ -1645,11 +1696,13 @@ end
     out.body[4][10, 15] = -0.2
     out.body_soil[1][10, 15] = -0.6
     out.body_soil[2][10, 15] = -0.5
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] == -0.8) && (out.terrain[9, 15] ≈ -0.1)
     @test (out.body_soil[1][10, 15] == -0.6) && (out.body_soil[2][10, 15] == -0.5)
     @test (out.body_soil[3][10, 15] ≈ -0.2) && (out.body_soil[4][10, 15] ≈ -0.1)
     @test (out.body_soil_pos == [[3; 10; 15]])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[9, 15] = 0.0
@@ -1662,6 +1715,7 @@ end
     out.body_soil[3][10, 15] = 0.0
     out.body_soil[4][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there are two bucket layers, the first layer with bucket soil
     # being lower, and the second bucket layer is high enough to prevent the soil from
@@ -1674,6 +1728,7 @@ end
     out.body[4][10, 15] = 0.0
     out.body_soil[1][10, 15] = -0.6
     out.body_soil[2][10, 15] = -0.5
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] == -0.8) && (out.terrain[9, 15] == 0.0)
     @test (out.terrain[10, 14] == 0.0) && (out.terrain[10, 16] == 0.0)
@@ -1681,6 +1736,7 @@ end
     @test (out.body_soil[1][10, 15] == -0.6) && (out.body_soil[2][10, 15] == -0.5)
     @test (out.body_soil[3][10, 15] == 0.0) && (out.body_soil[4][10, 15] == 0.0)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.body[1][10, 15] = 0.0
@@ -1690,6 +1746,7 @@ end
     out.body_soil[1][10, 15] = 0.0
     out.body_soil[2][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there are two bucket layers, the first layer being lower and it
     # has space under it, while the second layer is with bucket soil
@@ -1701,11 +1758,13 @@ end
     out.body[4][10, 15] = -0.3
     out.body_soil[3][10, 15] = -0.3
     out.body_soil[4][10, 15] = 0.4
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] ≈ -0.7) && (out.terrain[9, 15] ≈ -0.1)
     @test (out.body_soil[1][10, 15] == 0.0) && (out.body_soil[2][10, 15] == 0.0)
     @test (out.body_soil[3][10, 15] == -0.3) && (out.body_soil[4][10, 15] == 0.4)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[9, 15] = 0.0
@@ -1716,6 +1775,7 @@ end
     out.body_soil[3][10, 15] = 0.0
     out.body_soil[4][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there are two bucket layers, the first layer being lower, and
     # soil should avalanche on the second bucket layer with bucket soil
@@ -1727,11 +1787,13 @@ end
     out.body[4][10, 15] = -0.3
     out.body_soil[3][10, 15] = -0.3
     out.body_soil[4][10, 15] = -0.2
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] == -0.8) && (out.terrain[9, 15] ≈ -0.1)
     @test (out.body_soil[1][10, 15] == 0.0) && (out.body_soil[2][10, 15] == 0.0)
     @test (out.body_soil[3][10, 15] == -0.3) && (out.body_soil[4][10, 15] ≈ -0.1)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[9, 15] = 0.0
@@ -1742,6 +1804,7 @@ end
     out.body_soil[3][10, 15] = 0.0
     out.body_soil[4][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there are two bucket layers, the first layer being lower, and
     # the second bucket layer with bucket soil is high enough to prevent the soil from
@@ -1754,6 +1817,7 @@ end
     out.body[4][10, 15] = -0.3
     out.body_soil[3][10, 15] = -0.3
     out.body_soil[4][10, 15] = 0.0
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] == -0.8) && (out.terrain[9, 15] == 0.0)
     @test (out.terrain[10, 14] == 0.0) && (out.terrain[10, 16] == 0.0)
@@ -1761,6 +1825,7 @@ end
     @test (out.body_soil[1][10, 15] == 0.0) && (out.body_soil[2][10, 15] == 0.0)
     @test (out.body_soil[3][10, 15] == -0.3) && (out.body_soil[4][10, 15] == 0.0)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.body[1][10, 15] = 0.0
@@ -1770,6 +1835,7 @@ end
     out.body_soil[3][10, 15] = 0.0
     out.body_soil[4][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there are two bucket layers with bucket soil, the first layer
     # being lower and it has space under it
@@ -1783,11 +1849,13 @@ end
     out.body_soil[2][10, 15] = -0.5
     out.body_soil[3][10, 15] = -0.3
     out.body_soil[4][10, 15] = -0.1
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] ≈ -0.7) && (out.terrain[9, 15] ≈ -0.1)
     @test (out.body_soil[1][10, 15] == -0.6) && (out.body_soil[2][10, 15] == -0.5)
     @test (out.body_soil[3][10, 15] == -0.3) && (out.body_soil[4][10, 15] == -0.1)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[9, 15] = 0.0
@@ -1800,6 +1868,7 @@ end
     out.body_soil[3][10, 15] = 0.0
     out.body_soil[4][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there are two bucket layers with bucket soil, the first layer
     # being lower, and soil should avalanche on the second bucket layer
@@ -1813,11 +1882,13 @@ end
     out.body_soil[2][10, 15] = -0.5
     out.body_soil[3][10, 15] = -0.3
     out.body_soil[4][10, 15] = -0.2
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] == -0.8) && (out.terrain[9, 15] ≈ -0.1)
     @test (out.body_soil[1][10, 15] == -0.6) && (out.body_soil[2][10, 15] == -0.5)
     @test (out.body_soil[3][10, 15] == -0.3) && (out.body_soil[4][10, 15] ≈ -0.1)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[9, 15] = 0.0
@@ -1830,6 +1901,7 @@ end
     out.body_soil[3][10, 15] = 0.0
     out.body_soil[4][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there are two bucket layers with bucket soil, the first layer
     # being lower, and the second bucket layer is high enough to prevent the soil from
@@ -1844,12 +1916,15 @@ end
     out.body_soil[2][10, 15] = -0.5
     out.body_soil[3][10, 15] = -0.3
     out.body_soil[4][10, 15] = 0.0
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
+    _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] == -0.8) && (out.terrain[9, 15] == 0.0)
     @test (out.terrain[10, 14] == 0.0) && (out.terrain[10, 16] == 0.0)
     @test (out.terrain[11, 15] == 0.0)
     @test (out.body_soil[1][10, 15] == -0.6) && (out.body_soil[2][10, 15] == -0.5)
     @test (out.body_soil[3][10, 15] == -0.3) && (out.body_soil[4][10, 15] == 0.0)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.body[1][10, 15] = 0.0
@@ -1861,6 +1936,7 @@ end
     out.body_soil[3][10, 15] = 0.0
     out.body_soil[4][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there are two bucket layers, the second layer being lower and
     # it has space under it
@@ -1870,11 +1946,13 @@ end
     out.body[2][10, 15] = -0.1
     out.body[3][10, 15] = -0.7
     out.body[4][10, 15] = -0.6
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] ≈ -0.7) && (out.terrain[9, 15] ≈ -0.1)
     @test (out.body_soil[1][10, 15] == 0.0) && (out.body_soil[2][10, 15] == 0.0)
     @test (out.body_soil[3][10, 15] == 0.0) && (out.body_soil[4][10, 15] == 0.0)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[9, 15] = 0.0
@@ -1883,6 +1961,7 @@ end
     out.body[3][10, 15] = 0.0
     out.body[4][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there are two bucket layers, the second layer being lower, and
     # soil should avalanche on the first bucket layer
@@ -1892,11 +1971,13 @@ end
     out.body[2][10, 15] = -0.2
     out.body[3][10, 15] = -0.8
     out.body[4][10, 15] = -0.6
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] == -0.8) && (out.terrain[9, 15] ≈ -0.1)
     @test (out.body_soil[1][10, 15] ≈ -0.2) && (out.body_soil[2][10, 15] ≈ -0.1)
     @test (out.body_soil[3][10, 15] == 0.0) && (out.body_soil[4][10, 15] == 0.0)
     @test (out.body_soil_pos == [[1; 10; 15]])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[9, 15] = 0.0
@@ -1907,6 +1988,7 @@ end
     out.body_soil[1][10, 15] = 0.0
     out.body_soil[2][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there are two bucket layers, the second layer being lower, and
     # the first bucket layer is high enough to prevent the soil from avalanching
@@ -1916,12 +1998,15 @@ end
     out.body[2][10, 15] = 0.0
     out.body[3][10, 15] = -0.8
     out.body[4][10, 15] = -0.6
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
+    _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] == -0.8) && (out.terrain[9, 15] == 0.0)
     @test (out.terrain[10, 14] == 0.0) && (out.terrain[10, 16] == 0.0)
     @test (out.terrain[11, 15] == 0.0)
     @test (out.body_soil[1][10, 15] == 0.0) && (out.body_soil[2][10, 15] == 0.0)
     @test (out.body_soil[3][10, 15] == 0.0) && (out.body_soil[4][10, 15] == 0.0)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.body[1][10, 15] = 0.0
@@ -1929,6 +2014,7 @@ end
     out.body[3][10, 15] = 0.0
     out.body[4][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there are two bucket layers, the second layer with bucket soil
     # being lower and it has space under it
@@ -1940,11 +2026,13 @@ end
     out.body[4][10, 15] = -0.6
     out.body_soil[3][10, 15] = -0.6
     out.body_soil[4][10, 15] = -0.5
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] ≈ -0.7) && (out.terrain[9, 15] ≈ -0.1)
     @test (out.body_soil[1][10, 15] == 0.0) && (out.body_soil[2][10, 15] == 0.0)
     @test (out.body_soil[3][10, 15] == -0.6) && (out.body_soil[4][10, 15] == -0.5)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[9, 15] = 0.0
@@ -1955,6 +2043,7 @@ end
     out.body_soil[3][10, 15] = 0.0
     out.body_soil[4][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there are two bucket layers, the second layer with bucket soil
     # being lower, and soil should avalanche on the first bucket layer
@@ -1966,11 +2055,13 @@ end
     out.body[4][10, 15] = -0.6
     out.body_soil[3][10, 15] = -0.6
     out.body_soil[4][10, 15] = -0.5
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] == -0.8) && (out.terrain[9, 15] ≈ -0.1)
     @test (out.body_soil[1][10, 15] ≈ -0.2) && (out.body_soil[2][10, 15] ≈ -0.1)
     @test (out.body_soil[3][10, 15] == -0.6) && (out.body_soil[4][10, 15] == -0.5)
     @test (out.body_soil_pos == [[1; 10; 15]])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[9, 15] = 0.0
@@ -1983,6 +2074,7 @@ end
     out.body_soil[3][10, 15] = 0.0
     out.body_soil[4][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there are two bucket layers, the second layer with bucket soil
     # being lower, and the first bucket layer is high enough to prevent the soil from
@@ -1995,6 +2087,7 @@ end
     out.body[4][10, 15] = -0.6
     out.body_soil[3][10, 15] = -0.6
     out.body_soil[4][10, 15] = -0.5
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] == -0.8) && (out.terrain[9, 15] == 0.0)
     @test (out.terrain[10, 14] == 0.0) && (out.terrain[10, 16] == 0.0)
@@ -2002,6 +2095,7 @@ end
     @test (out.body_soil[1][10, 15] == 0.0) && (out.body_soil[2][10, 15] == 0.0)
     @test (out.body_soil[3][10, 15] == -0.6) && (out.body_soil[4][10, 15] == -0.5)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.body[1][10, 15] = 0.0
@@ -2011,6 +2105,7 @@ end
     out.body_soil[3][10, 15] = 0.0
     out.body_soil[4][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there are two bucket layers, the second layer being lower and
     # has space under it, while the first layer is with bucket soil
@@ -2022,11 +2117,13 @@ end
     out.body[4][10, 15] = -0.6
     out.body_soil[1][10, 15] = -0.3
     out.body_soil[2][10, 15] = -0.1
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] ≈ -0.7) && (out.terrain[9, 15] ≈ -0.1)
     @test (out.body_soil[1][10, 15] == -0.3) && (out.body_soil[2][10, 15] == -0.1)
     @test (out.body_soil[3][10, 15] == 0.0) && (out.body_soil[4][10, 15] == 0.0)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[9, 15] = 0.0
@@ -2037,6 +2134,7 @@ end
     out.body_soil[1][10, 15] = 0.0
     out.body_soil[2][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there are two bucket layers, the second layer being lower, and
     # soil should avalanche on the first bucket layer with bucket soil
@@ -2048,11 +2146,13 @@ end
     out.body[4][10, 15] = -0.6
     out.body_soil[1][10, 15] = -0.3
     out.body_soil[2][10, 15] = -0.2
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] == -0.8) && (out.terrain[9, 15] ≈ -0.1)
     @test (out.body_soil[1][10, 15] == -0.3) && (out.body_soil[2][10, 15] ≈ -0.1)
     @test (out.body_soil[3][10, 15] == 0.0) && (out.body_soil[4][10, 15] == 0.0)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[9, 15] = 0.0
@@ -2063,6 +2163,7 @@ end
     out.body_soil[1][10, 15] = 0.0
     out.body_soil[2][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there are two bucket layers, the second layer being lower, and
     # the first bucket layer with bucket soil is high enough to prevent the soil from
@@ -2075,6 +2176,7 @@ end
     out.body[4][10, 15] = -0.6
     out.body_soil[1][10, 15] = -0.3
     out.body_soil[2][10, 15] = 0.0
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] == -0.8) && (out.terrain[9, 15] == 0.0)
     @test (out.terrain[10, 14] == 0.0) && (out.terrain[10, 16] == 0.0)
@@ -2082,6 +2184,7 @@ end
     @test (out.body_soil[1][10, 15] == -0.3) && (out.body_soil[2][10, 15] == 0.0)
     @test (out.body_soil[3][10, 15] == 0.0) && (out.body_soil[4][10, 15] == 0.0)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.body[1][10, 15] = 0.0
@@ -2091,6 +2194,7 @@ end
     out.body_soil[1][10, 15] = 0.0
     out.body_soil[2][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there are two bucket layers with bucket soil, the second layer
     # being lower and has space under it
@@ -2104,11 +2208,13 @@ end
     out.body_soil[2][10, 15] = -0.1
     out.body_soil[3][10, 15] = -0.6
     out.body_soil[4][10, 15] = -0.5
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] ≈ -0.7) && (out.terrain[9, 15] ≈ -0.1)
     @test (out.body_soil[1][10, 15] == -0.3) && (out.body_soil[2][10, 15] == -0.1)
     @test (out.body_soil[3][10, 15] == -0.6) && (out.body_soil[4][10, 15] == -0.5)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[9, 15] = 0.0
@@ -2121,6 +2227,7 @@ end
     out.body_soil[3][10, 15] = 0.0
     out.body_soil[4][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there are two bucket layers with bucket soil, the second layer
     # being lower, and soil should avalanche on the first bucket layer
@@ -2134,11 +2241,13 @@ end
     out.body_soil[2][10, 15] = -0.2
     out.body_soil[3][10, 15] = -0.6
     out.body_soil[4][10, 15] = -0.5
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] == -0.8) && (out.terrain[9, 15] ≈ -0.1)
     @test (out.body_soil[1][10, 15] == -0.3) && (out.body_soil[2][10, 15] ≈ -0.1)
     @test (out.body_soil[3][10, 15] == -0.6) && (out.body_soil[4][10, 15] == -0.5)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[9, 15] = 0.0
@@ -2151,6 +2260,7 @@ end
     out.body_soil[3][10, 15] = 0.0
     out.body_soil[4][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the case where there are two bucket layers with bucket soil, the second layer
     # being lower, and the first bucket layer is high enough to prevent the soil from
@@ -2165,6 +2275,7 @@ end
     out.body_soil[2][10, 15] = 0.0
     out.body_soil[3][10, 15] = -0.6
     out.body_soil[4][10, 15] = -0.5
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] == -0.8) && (out.terrain[9, 15] == 0.0)
     @test (out.terrain[10, 14] == 0.0) && (out.terrain[10, 16] == 0.0)
@@ -2172,6 +2283,7 @@ end
     @test (out.body_soil[1][10, 15] == -0.3) && (out.body_soil[2][10, 15] == 0.0)
     @test (out.body_soil[3][10, 15] == -0.6) && (out.body_soil[4][10, 15] == -0.5)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.body[1][10, 15] = 0.0
@@ -2183,12 +2295,14 @@ end
     out.body_soil[3][10, 15] = 0.0
     out.body_soil[4][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the edge case where a lot of space under the bucket is present
     set_RNG_seed!(1234)
     out.terrain[10, 15] = -0.6
     out.body[1][10, 15] = 0.0
     out.body[2][10, 15] = 0.2
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] ≈ -0.1) && (out.terrain[9, 15] ≈ -0.3)
     @test (out.terrain[10, 14] ≈ -0.1) && (out.terrain[10, 16] ≈ -0.1)
@@ -2196,6 +2310,7 @@ end
     @test (out.body_soil[1][10, 15] == 0.0) && (out.body_soil[2][10, 15] == 0.0)
     @test (out.body_soil[3][10, 15] == 0.0) && (out.body_soil[4][10, 15] == 0.0)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[9, 15] = 0.0
@@ -2204,37 +2319,45 @@ end
     out.body[1][10, 15] = 0.0
     out.body[2][10, 15] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing the edge case for soil avalanching on terrain
     set_RNG_seed!(1234)
     out.terrain[10, 15] = -0.4
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] ≈ -0.1) && (out.terrain[9, 15] ≈ -0.2)
     @test (out.terrain[10, 14] ≈ -0.1) && (out.terrain[10, 16] == 0.0)
     @test (out.terrain[11, 15] == 0.0)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[9, 15] = 0.0
     out.terrain[10, 14] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Testing randomization
     set_RNG_seed!(1234)
     out.terrain[10, 15] = -0.2
+    out.relax_area[:, :] .= Int64[[10, 15] [10, 15]]
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] ≈ -0.1) && (out.terrain[9, 15] ≈ -0.1)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     out.terrain[10, 15] = -0.2
     out.terrain[9, 15] = 0.0
     set_RNG_seed!(1235)
     _relax_terrain!(out, grid, sim)
     @test (out.terrain[10, 15] ≈ -0.1) && (out.terrain[10, 14] ≈ -0.1)
     @test (out.body_soil_pos == [])
+    @test (out.relax_area == Int64[[5, 10] [15, 20]])
     # Resetting values
     out.terrain[10, 15] = 0.0
     out.terrain[10, 14] = 0.0
     empty!(out.body_soil_pos)
+    out.relax_area[:, :] .= Int64[[0, 0] [0, 0]]
 
     # Removing zeros from Sparse matrices
     dropzeros!(out.body[1])

--- a/test/unit_test/test_relax.jl
+++ b/test/unit_test/test_relax.jl
@@ -17,7 +17,8 @@ grid = GridParam(grid_size_x, grid_size_y, grid_size_z, cell_size_xy, cell_size_
 # Simulation properties
 repose_angle = 0.785
 max_iterations = 3
-sim = SimParam(repose_angle, max_iterations)
+cell_buffer = 4
+sim = SimParam(repose_angle, max_iterations, cell_buffer)
 
 # Terrain properties
 terrain = zeros(2 * grid.half_length_x + 1, 2 * grid.half_length_y + 1)

--- a/test/unit_test/test_relax.jl
+++ b/test/unit_test/test_relax.jl
@@ -39,6 +39,7 @@ out = SimOut(terrain, grid)
     out.terrain[7, 13] = 0.1
     out.terrain[15, 5] = -0.4
     out.terrain[15, 6] = -0.2
+    out.impact_area[:, :] .= Int64[[2, 2] [16, 14]]
 
     # Testing that all unstable cells are properly located
     unstable_cells = _locate_unstable_terrain_cell(out, 0.1)
@@ -53,6 +54,7 @@ out = SimOut(terrain, grid)
     @test (length(unstable_cells) == 15)
     # Resetting terrain
     out.terrain[:, :] .= 0.0
+    out.impact_area[:, :] .= Int64[[0, 0] [0, 0]]
 end
 
 @testset "_check_unstable_terrain_cell!" begin
@@ -1287,6 +1289,9 @@ end
 end
 
 @testset "_relax_terrain!" begin
+    # Setting impact_area
+    out.impact_area[:, :] .= Int64[[5, 10] [15, 20]]
+
     # Testing the case where there is no bucket and soil is unstable
     set_RNG_seed!(1234)
     out.terrain[10, 15] = -0.2
@@ -2379,6 +2384,9 @@ end
     @test isempty(nonzeros(out.body_soil[2]))
     @test isempty(nonzeros(out.body_soil[3]))
     @test isempty(nonzeros(out.body_soil[4]))
+
+    # Resetting impact_area
+    out.impact_area[:, :] .= Int64[[0, 0] [0, 0]]
 end
 
 @testset "_check_unstable_body_cell!" begin

--- a/test/unit_test/test_types.jl
+++ b/test/unit_test/test_types.jl
@@ -35,6 +35,7 @@ cell_buffer = 4
 
 # Terrain properties
 terrain = zeros(2 * grid_half_length_x + 1, 2 * grid_half_length_y + 1)
+area = zeros(Int64, 2, 2)
 
 
 #==========================================================================================#
@@ -216,6 +217,9 @@ end
     @test out.body isa Vector{SparseMatrixCSC{Float64,Int64}}
     @test out.body_soil isa Vector{SparseMatrixCSC{Float64,Int64}}
     @test out.body_soil_pos isa Vector{Vector{Int64}}
+    @test out.bucket_area == area
+    @test out.relax_area == area
+    @test out.impact_area == area
 
     # Testing that incorrect terrain size throws an error
     @test_throws DimensionMismatch SimOut(zeros(10, 3), grid)

--- a/test/unit_test/test_types.jl
+++ b/test/unit_test/test_types.jl
@@ -31,6 +31,7 @@ bucket_width = 0.5
 # Simulation properties
 repose_angle = 0.85
 max_iterations = 3
+cell_buffer = 4
 
 # Terrain properties
 terrain = zeros(2 * grid_half_length_x + 1, 2 * grid_half_length_y + 1)
@@ -162,8 +163,8 @@ end
 
 @testset "SimParam struct" begin
     # Creating dummy SimParam by using the inner constructor
-    @test_nowarn SimParam(repose_angle, max_iterations)
-    sim_param = SimParam(repose_angle, max_iterations)
+    @test_nowarn SimParam(repose_angle, max_iterations, cell_buffer)
+    sim_param = SimParam(repose_angle, max_iterations, cell_buffer)
 
     # Testing the type of the struct
     @test sim_param isa SimParam
@@ -171,21 +172,30 @@ end
     # Testing properties of the struct
     @test sim_param.repose_angle == repose_angle
     @test sim_param.max_iterations == max_iterations
+    @test sim_param.cell_buffer == cell_buffer
 
     # Testing that repose_angle outside the allowed range throws an error
-    @test_throws DomainError SimParam(-0.1, max_iterations)
-    @test_throws DomainError SimParam(3.14, max_iterations)
+    @test_throws DomainError SimParam(-0.1, max_iterations, cell_buffer)
+    @test_throws DomainError SimParam(3.14, max_iterations, cell_buffer)
  
     # Testing that repose_angle on the edge of the allowed range does not throw an error
-    @test_nowarn SimParam(0.0, max_iterations)
-    @test_nowarn SimParam(pi / 2, max_iterations)
+    @test_nowarn SimParam(0.0, max_iterations, cell_buffer)
+    @test_nowarn SimParam(pi / 2, max_iterations, cell_buffer)
 
     # Testing that max_iterations lower than zero throws an error
-    @test_throws DomainError SimParam(repose_angle, -1)
-    @test_throws DomainError SimParam(repose_angle, -10)
+    @test_throws DomainError SimParam(repose_angle, -1, cell_buffer)
+    @test_throws DomainError SimParam(repose_angle, -10, cell_buffer)
 
     # Testing that max_iterations equal to zero does not throw an error
-    @test_nowarn SimParam(repose_angle, 0)
+    @test_nowarn SimParam(repose_angle, 0, cell_buffer)
+
+    # Testing that cell_buffer lower than 2 throws a warning
+    warning_message = "cell_buffer too low, setting to 2"
+    @test_logs (:warn, warning_message) SimParam(repose_angle, max_iterations, 1)
+    @test_logs (:warn, warning_message) SimParam(repose_angle, max_iterations, 0)
+
+    # Testing that cell_buffer equal to 2 does not throw a warning
+    @test_nowarn SimParam(repose_angle, max_iterations, 2)
 end
 
 @testset "SimOut struct" begin


### PR DESCRIPTION
# Description
- Added three working areas: `bucket_area`, `relax_area` and `impact_area`.
    - `bucket_area` corresponds to the 2D bounding box of the bucket.
    - `relax_area` corresponds to the 2D bounding box of places where the soil is unstable.
    - `impact_area` is the union of `bucket_area` and `relax_area`.
- Added `cell_buffer` into `SimParam` to specify the number of buffer cells for the working areas
- `bucket_area` is built in `calc_bucket_pos`
- `relax_area` is built in `relax_terrain`
- `impact_area` is calculated before each relaxation iteration in `soil_dynamics`
- `_locate_unstable_terrain_cell` is now only iterating over the `impact_area`.
- Unit tests had been adjusted accordingly
- Benchmarking had been adjusted accordingly
- Logging is enabled after benchmarking
- The example script `soil_evolution` had been adjusted accordingly

# Note
Computational time for the example digging scoop is decreased from 180ms to 115ms.
Further speed up can be done by reducing the number of relaxation iterations.