### PR TITLE
Improve movement of intersecting cells

### DIFF
--- a/src/SoilDynamics.jl
+++ b/src/SoilDynamics.jl
@@ -23,7 +23,8 @@ export _update_body_soil!
 
 # intersecting_cells.jl
 export _move_intersecting_cells!
-export _move_intersecting_body!, _move_intersecting_body_soil!, _locate_intersecting_cells
+export _move_intersecting_body_soil!, _move_body_soil!
+export _move_intersecting_body!, _locate_intersecting_cells
 
 # relax.jl
 export _relax_terrain!, _relax_body_soil!

--- a/src/intersecting_cells.jl
+++ b/src/intersecting_cells.jl
@@ -350,6 +350,64 @@ function _locate_intersecting_cells(
     return intersecting_cells
 end
 
+"""
+    _move_body_soil!(
+        out::SimOut{B,I,T}, ind_p::I, ii_p::I, jj_p::I, max_h::T, ii_n::I, jj_n::I,
+        h_soil::T, wall_presence::B, tol::T=1e-8
+    ) where {B<:Bool,I<:Int64,T<:Float64}
+
+This function tries to move the soil cells resting on the bucket layer `ind_p` at the
+location (`ii_p`, `jj_p`) to a new location at (`ii_n`, `jj_n`).
+
+This function can be separated into three main scenarios:
+- If all the soil can be moved to the new location (either on the terrain or on the bucket),
+  the soil is moved and the value of `h_soil` is set to zero.
+- If a bucket wall is blocking the movement, the `wall_presence` parameter is set to `true`.
+- If there is insufficient space to move all the soil but no bucket wall is blocking the
+  movement, the function updates the values for the new location and adjusts `h_soil`
+  accordingly.
+
+This function is designed to be used iteratively by `_move_intersecting_body_soil!` until
+all intersecting soil cells are moved.
+
+# Note
+- This function is intended for internal use only.
+- By convention, the soil can be moved from the bucket to the terrain even if the bucket is
+  underground.
+- In cases where the soil should be moved to the terrain, all soil is moved regardless of
+  the available space. If this movement induces intersecting soil cells, it will be resolved
+  by the `_move_intersecting_body!` function.
+
+# Inputs
+- `out::SimOut{Bool,Int64,Float64}`: Struct that stores simulation outputs.
+- `ind_p::Int64`: Index of the previous considered bucket layer.
+- `ii_p::Int64`: Index of the previous considered position in the X direction.
+- `jj_p::Int64`: Index of the previous considered position in the Y direction.
+- `max_h::Float64`: Maximum height authorized for the movement. [m]
+- `ii_n::Int64`: Index of the new considered position in the X direction.
+- `jj_n::Int64`: Index of the new considered position in the Y direction.
+- `h_soil::Float64`: Height of the soil column left to be moved. [m]
+- `wall_presence::Bool`: Indicates whether a bucket wall is blocking the movement.
+- `tol::Float64`: Small number used to handle numerical approximation errors.
+
+# Outputs
+- `ind_p::Int64`: Index of the new considered bucket layer.
+- `ii_p::Int64`: Index of the new considered position in the X direction.
+- `jj_p::Int64`: Index of the new considered position in the Y direction.
+- `max_h::Float64`: Maximum height authorized for the next movement. [m]
+- `h_soil::Float64`: Height of the soil column left to be moved. [m]
+- `wall_presence::Bool`: Indicates whether a bucket wall is blocking the movement.
+
+# Example
+
+    grid = GridParam(4.0, 4.0, 3.0, 0.05, 0.01)
+    terrain = zeros(2 * grid.half_length_x + 1, 2 * grid.half_length_y + 1)
+    out = SimOut(terrain, grid)
+
+     ind_p, ii_p, jj_p, max_h, h_soil, wall_presence = _move_body_soil!(
+         out, 1, 10, 15, 0.2, 10, 16, 0.2, true
+     )
+"""
 function _move_body_soil!(
     out::SimOut{B,I,T},
     ind_p::I,

--- a/src/intersecting_cells.jl
+++ b/src/intersecting_cells.jl
@@ -244,23 +244,23 @@ function _move_intersecting_body_soil!(
 
         if (ind == 1)
             ### First bucket soil layer ###
-            ind_top = 3
+            ind_t = 3
         else
             ### Second bucket soil layer ###
-            ind_top = 1
+            ind_t = 1
         end
 
-        if (out.body[ind_top][ii, jj] == 0.0) && (out.body[ind_top+1][ii, jj] == 0.0)
+        if (out.body[ind_t][ii, jj] == 0.0) && (out.body[ind_t+1][ii, jj] == 0.0)
             ### No additionnal bucket layer ###
             continue
         end
 
         if (
-            (out.body_soil[ind+1][ii, jj] - tol > out.body[ind_top][ii, jj]) &&
-            (out.body[ind_top+1][ii, jj] - tol > out.body_soil[ind][ii, jj])
+            (out.body_soil[ind+1][ii, jj] - tol > out.body[ind_t][ii, jj]) &&
+            (out.body[ind_t+1][ii, jj] - tol > out.body_soil[ind][ii, jj])
         )
             ### Bucket soil intersects with bucket ###
-            h_soil = out.body_soil[ind+1][ii, jj] - out.body[ind_top][ii, jj]
+            h_soil = out.body_soil[ind+1][ii, jj] - out.body[ind_t][ii, jj]
         else
             ### No intersection between bucket soil and bucket ###
             continue
@@ -274,7 +274,7 @@ function _move_intersecting_body_soil!(
             nn = 0
             wall_presence = false
             ind_p = ind
-            ind_top_p = ind_top
+            ind_t_p = ind_t
             
 
             # Exploring the direction until reaching a wall
@@ -287,7 +287,7 @@ function _move_intersecting_body_soil!(
                 # Calculating previous position
                 ii_p = ii + (nn - 1) * xy[1]
                 jj_p = jj + (nn - 1) * xy[2]
-Need to have ind_top_p and ind_p as well...
+Need to have ind_t_p and ind_p as well...
 
             end
             if (h_soil < tol)
@@ -302,7 +302,7 @@ Need to have ind_top_p and ind_p as well...
         end
 
         # Updating bucket soil
-        out.body_soil[ind+1][ii, jj] = out.body[ind_top][ii, jj]
+        out.body_soil[ind+1][ii, jj] = out.body[ind_t][ii, jj]
     end
 end
 
@@ -391,28 +391,27 @@ function _move_body_soil!(
                 h_soil = 0.0
                 break
             end
-        elseif (out.body[4][ii_n, jj_n] + tol > out.body[ind_top_p][ii_p, jj_p])
+        elseif (out.body[4][ii_n, jj_n] + tol > out.body[ind_t_p][ii_p, jj_p])
             ### Bucket is blocking the movement ###
             wall_presence = true
             continue
         end
 
         bucket_soil_presence_3 = (
-            (out.body_soil[3][ii_n, jj_n] != 0.0) ||
-            (out.body_soil[4][ii_n, jj_n] != 0.0)
+            (out.body_soil[3][ii_n, jj_n] != 0.0) || (out.body_soil[4][ii_n, jj_n] != 0.0)
         )
 
         if (
             bucket_soil_presence_3 &&
-            (out.body_soil[4][ii_n, jj_n] + tol > out.body[ind_top_p][ii_p, jj_p])
+            (out.body_soil[4][ii_n, jj_n] + tol > out.body[ind_t_p][ii_p, jj_p])
         )
             ### Soil is blocking the movement ###
             continue
         end
 
         # The only option left is that there is space for the intersecting soil
-        # Note that there is necessarily enough space for all the soil,
-        # otherwise the soil column would block the movement
+        # Note that there is necessarily enough space for all the soil, otherwise the soil
+        # column would block the movement
         if (bucket_soil_presence_3)
             ### Soil should go into the existing bucket soil layer ###
             out.body_soil[4][ii_n, jj_n] += h_soil
@@ -444,28 +443,27 @@ function _move_body_soil!(
                 h_soil = 0.0
                 break
             end
-        elseif (out.body[2][ii_n, jj_n] + tol > out.body[ind_top_p][ii_p, jj_p])
+        elseif (out.body[2][ii_n, jj_n] + tol > out.body[ind_t_p][ii_p, jj_p])
             ### Bucket is blocking the movement ###
             wall_presence = true
             continue
         end
 
         bucket_soil_presence_1 = (
-            (out.body_soil[1][ii_n, jj_n] != 0.0) ||
-            (out.body_soil[2][ii_n, jj_n] != 0.0)
+            (out.body_soil[1][ii_n, jj_n] != 0.0) || (out.body_soil[2][ii_n, jj_n] != 0.0)
         )
 
         if (
             bucket_soil_presence_1 &&
-            (out.body_soil[2][ii_n, jj_n] + tol > out.body[ind_top_p][ii_p, jj_p])
+            (out.body_soil[2][ii_n, jj_n] + tol > out.body[ind_t_p][ii_p, jj_p])
         )
             ### Soil is blocking the movement ###
             continue
         end
 
         # The only option left is that there is space for the intersecting soil
-        # Note that there is necessarily enough space for all the soil,
-        # otherwise the soil column would block the movement
+        # Note that there is necessarily enough space for all the soil, otherwise the soil
+        # column would block the movement
         if (bucket_soil_presence_1)
             ### Soil should go into the existing bucket soil layer ###
             out.body_soil[2][ii_n, jj_n] += h_soil
@@ -484,39 +482,32 @@ function _move_body_soil!(
         ### Both bucket layers are present ###
         if (out.body[1][ii_n, jj_n] < out.body[3][ii_n, jj_n])
             ### First layer at bottom ###
-            ind_n_bot = 1
-            ind_n_top = 3
+            ind_b_n = 1
+            ind_t_n = 3
         else
             ### Second layer at bottom ###
-            ind_n_bot = 3
-            ind_n_top = 1
+            ind_b_n = 3
+            ind_t_n = 1
         end
 
         bucket_soil_presence = (
-            (out.body_soil[ind_n_bot][ii_n, jj_n] != 0.0) ||
-            (out.body_soil[ind_n_bot+1][ii_n, jj_n] != 0.0)
+            (out.body_soil[ind_b_n][ii_n, jj_n] != 0.0) ||
+            (out.body_soil[ind_b_n+1][ii_n, jj_n] != 0.0)
         )
 
         if (bucket_soil_presence)
             ### Bucket soil is present between the two bucket layers ###
-            if (
-                out.body_soil[ind_n_bot+1][ii_n, jj_n] + tol >
-                out.body[ind_n_top][ii_n, jj_n]
-            )
+            if (out.body_soil[ind_b_n+1][ii_n, jj_n] + tol > out.body[ind_t_n][ii_n, jj_n])
                 ### Bucket and soil blocking the movement ###
                 continue
             elseif (
-                out.body_soil[ind_n_bot+1][ii_n, jj_n] + tol >
-                out.body[ind_top_p][ii_p, jj_p]
+                out.body_soil[ind_b_n+1][ii_n, jj_n] + tol > out.body[ind_t_p][ii_p, jj_p]
             )
                 ### Bucket and soil blocking the movement ###
                 continue
             end
         else
-            if (
-                out.body[ind_n_bot+1][ii_n, jj_n] + tol >
-                out.body[ind_top_p][ii_p, jj_p]
-            )
+            if (out.body[ind_b_n+1][ii_n, jj_n] + tol > out.body[ind_t_p][ii_p, jj_p])
                 ### Bucket is blocking the movement ###
                 wall_presence = true
                 continue
@@ -527,21 +518,18 @@ function _move_body_soil!(
         if (bucket_soil_presence)
             ### Soil should go into the existing bucket soil layer ###
             # Calculating available space
-            delta_h = (
-                out.body[ind_n_top][ii_n, jj_n] -
-                out.body_soil[ind_n_bot+1][ii_n, jj_n]
-            )
+            delta_h = out.body[ind_t_n][ii_n, jj_n] - out.body_soil[ind_b_n+1][ii_n, jj_n]
 
             if (delta_h < h_soil)
                 ### Not enough space ###
                 h_soil -= delta_h
 
                 # Adding soil to the bucket soil layer
-                out.body_soil[ind_n_bot+1][ii_n, jj_n] += delta_h
+                out.body_soil[ind_b_n+1][ii_n, jj_n] += delta_h
             else
                 ### More space than soil ###
                 # Adding soil to the bucket soil layer
-                out.body_soil[ind_n_bot+1][ii_n, jj_n] += h_soil
+                out.body_soil[ind_b_n+1][ii_n, jj_n] += h_soil
 
                 h_soil = 0.0
                 break
@@ -549,37 +537,30 @@ function _move_body_soil!(
         else
             ### Soil should create a new bucket soil layer ###
             # Calculating available space
-            delta_h = (
-                out.body[ind_n_top][ii_n, jj_n] -
-                out.body[ind_n_bot+1][ii_n, jj_n]
-            )
+            delta_h = out.body[ind_t_n][ii_n, jj_n] - out.body[ind_b_n+1][ii_n, jj_n]
 
             if (delta_h < h_soil)
                 ### Not enough space ###
                 h_soil -= delta_h
 
                 # Creating a new bucket soil layer
-                out.body_soil[ind_n_bot][ii_n, jj_n] = (
-                    out.body[ind_n_bot+1][ii_n, jj_n]
-                )
-                out.body_soil[ind_n_bot+1][ii_n, jj_n] = (
-                    out.body[ind_n_bot+1][ii_n, jj_n] + delta_h
+                out.body_soil[ind_b_n][ii_n, jj_n] = out.body[ind_b_n+1][ii_n, jj_n]
+                out.body_soil[ind_b_n+1][ii_n, jj_n] = (
+                    out.body[ind_b_n+1][ii_n, jj_n] + delta_h
                 )
 
                 # Adding new bucket soil position to body_soil_pos
-                push!(out.body_soil_pos, [ind_n_bot; ii_n; jj_n])
+                push!(out.body_soil_pos, [ind_b_n; ii_n; jj_n])
             else
                 ### More space than soil ###
                 # Creating a new bucket soil layer
-                out.body_soil[ind_n_bot][ii_n, jj_n] = (
-                    out.body[ind_n_bot+1][ii_n, jj_n]
-                )
-                out.body_soil[ind_n_bot+1][ii_n, jj_n] = (
-                    out.body[ind_n_bot+1][ii_n, jj_n] + h_soil
+                out.body_soil[ind_b_n][ii_n, jj_n] = out.body[ind_b_n+1][ii_n, jj_n]
+                out.body_soil[ind_b_n+1][ii_n, jj_n] = (
+                    out.body[ind_b_n+1][ii_n, jj_n] + h_soil
                 )
 
                 # Adding new bucket soil position to body_soil_pos
-                push!(out.body_soil_pos, [ind_n_bot; ii_n; jj_n])
+                push!(out.body_soil_pos, [ind_b_n; ii_n; jj_n])
 
                 h_soil = 0.0
                 break

--- a/src/intersecting_cells.jl
+++ b/src/intersecting_cells.jl
@@ -277,7 +277,7 @@ function _move_intersecting_body_soil!(
                 ii_n = ii + nn * xy[1]
                 jj_n = jj + nn * xy[2]
 
-                _move_body_soil!(
+                ind_p, ii_p, jj_p, max_h, h_soil, wall_presence = _move_body_soil!(
                     out, ind_p, ii_p, jj_p, max_h, ii_n, jj_n, h_soil, wall_presence, tol
                 )
             end
@@ -370,6 +370,7 @@ function _move_body_soil!(
         ### No bucket ###
         out.terrain[ii_n, jj_n] += h_soil
         h_soil = 0.0
+        return ind_p, ii_p, jj_p, max_h, h_soil, wall_presence
     elseif (bucket_absence_1)
         ### Only the second bucket layer ###
         if (out.body[3][ii_n, jj_n] - tol > out.body[ind_p+1][ii_p, jj_p])
@@ -379,11 +380,11 @@ function _move_body_soil!(
             # with the bucket and later be moved by the _move_intersecting_body! function
             out.terrain[ii_n, jj_n] += h_soil
             h_soil = 0.0
-            return
+            return ind_p, ii_p, jj_p, max_h, h_soil, wall_presence
         elseif (out.body[4][ii_n, jj_n] + tol > max_h)
             ### Bucket is blocking the movement ###
             wall_presence = true
-            return
+            return ind_p, ii_p, jj_p, max_h, h_soil, wall_presence
         end
 
         bucket_soil_presence_3 = (
@@ -393,7 +394,11 @@ function _move_body_soil!(
         if (bucket_soil_presence_3 && (out.body_soil[4][ii_n, jj_n] + tol > max_h))
             ### Soil is blocking the movement ###
 ##
-            return
+            # Updating previous position
+            ii_p = ii_n
+            jj_p = jj_n
+            ind_p = 3
+            return ind_p, ii_p, jj_p, max_h, h_soil, wall_presence
         end
 
         # The only option left is that there is space for the intersecting soil
@@ -421,11 +426,11 @@ function _move_body_soil!(
             # with the bucket and later be moved by the _move_intersecting_body! function
             out.terrain[ii_n, jj_n] += h_soil
             h_soil = 0.0
-            return
+            return ind_p, ii_p, jj_p, max_h, h_soil, wall_presence
         elseif (out.body[2][ii_n, jj_n] + tol > max_h)
             ### Bucket is blocking the movement ###
             wall_presence = true
-            return
+            return ind_p, ii_p, jj_p, max_h, h_soil, wall_presence
         end
 
         bucket_soil_presence_1 = (
@@ -434,8 +439,12 @@ function _move_body_soil!(
 
         if (bucket_soil_presence_1 && (out.body_soil[2][ii_n, jj_n] + tol > max_h))
             ### Soil is blocking the movement ###
+            # Updating previous position
+            ii_p = ii_n
+            jj_p = jj_n
+            ind_p = 1
 ##
-            return
+            return ind_p, ii_p, jj_p, max_h, h_soil, wall_presence
         end
 
         # The only option left is that there is space for the intersecting soil
@@ -480,7 +489,7 @@ function _move_body_soil!(
                 jj_p = jj_n
                 ind_p = ind_b_n
                 max_h = out.body[ind_t_n][ii_n, jj_n]
-                return
+                return ind_p, ii_p, jj_p, max_h, h_soil, wall_presence
             elseif (out.body_soil[ind_b_n+1][ii_n, jj_n] + tol > max_h)
                 ### Bucket and soil blocking the movement ###
                 # Updating previous position
@@ -488,13 +497,13 @@ function _move_body_soil!(
                 jj_p = jj_n
                 ind_p = ind_b_n
                 max_h = out.body[ind_t_n][ii_n, jj_n]
-                return
+                return ind_p, ii_p, jj_p, max_h, h_soil, wall_presence
             end
         else
             if (out.body[ind_b_n+1][ii_n, jj_n] + tol > max_h)
                 ### Bucket is blocking the movement ###
                 wall_presence = true
-                return
+                return ind_p, ii_p, jj_p, max_h, h_soil, wall_presence
             end
         end
 
@@ -561,4 +570,6 @@ function _move_body_soil!(
             end
         end
     end
+
+    return  ind_p, ii_p, jj_p, max_h, h_soil, wall_presence
 end

--- a/src/intersecting_cells.jl
+++ b/src/intersecting_cells.jl
@@ -482,13 +482,21 @@ function _move_body_soil!(
             ### Bucket soil is present between the two bucket layers ###
             if (out.body_soil[ind_b_n+1][ii_n, jj_n] + tol > out.body[ind_t_n][ii_n, jj_n])
                 ### Bucket and soil blocking the movement ###
-##
+                # Updating previous position
+                ii_p = ii_n
+                jj_p = jj_n
+                ind_p = ind_b_n
+                ind_t_p = ind_t_n
                 return
             elseif (
                 out.body_soil[ind_b_n+1][ii_n, jj_n] + tol > out.body[ind_t_p][ii_p, jj_p]
             )
                 ### Bucket and soil blocking the movement ###
-##
+                # Updating previous position
+                ii_p = ii_n
+                jj_p = jj_n
+                ind_p = ind_b_n
+                ind_t_p = ind_t_n
                 return
             end
         else
@@ -511,7 +519,12 @@ function _move_body_soil!(
 
                 # Adding soil to the bucket soil layer
                 out.body_soil[ind_b_n+1][ii_n, jj_n] += delta_h
-##
+
+                # Updating previous position
+                ii_p = ii_n
+                jj_p = jj_n
+                ind_p = ind_b_n
+                ind_t_p = ind_t_n
             else
                 ### More space than soil ###
                 # Adding soil to the bucket soil layer
@@ -536,7 +549,12 @@ function _move_body_soil!(
 
                 # Adding new bucket soil position to body_soil_pos
                 push!(out.body_soil_pos, [ind_b_n; ii_n; jj_n])
-##
+
+                # Updating previous position
+                ii_p = ii_n
+                jj_p = jj_n
+                ind_p = ind_b_n
+                ind_t_p = ind_t_n
             else
                 ### More space than soil ###
                 # Creating a new bucket soil layer

--- a/src/intersecting_cells.jl
+++ b/src/intersecting_cells.jl
@@ -268,8 +268,7 @@ function _move_intersecting_body_soil!(
             ii_p = ii
             jj_p = jj
             ind_p = ind
-            ind_t_p = ind_t
-            
+            max_h = out.body[ind_t][ii, jj]
 
             # Exploring the direction until reaching a wall or all soil has been moved
             while (!wall_presence && h_soil > tol)
@@ -279,7 +278,7 @@ function _move_intersecting_body_soil!(
                 jj_n = jj + nn * xy[2]
 
                 _move_body_soil!(
-                    out, ind_p, ind_t_p, ii_p, jj_p, ii_n, jj_n, h_soil, wall_presence, tol
+                    out, ind_p, ii_p, jj_p, max_h, ii_n, jj_n, h_soil, wall_presence, tol
                 )
             end
             if (h_soil < tol)
@@ -349,9 +348,9 @@ end
 function _move_body_soil!(
     out::SimOut{B,I,T},
     ind_p::I,
-    ind_t_p::I,
     ii_p::I,
     jj_p::I,
+    max_h::T,
     ii_n::I,
     jj_n::I,
     h_soil::T,
@@ -381,7 +380,7 @@ function _move_body_soil!(
             out.terrain[ii_n, jj_n] += h_soil
             h_soil = 0.0
             return
-        elseif (out.body[4][ii_n, jj_n] + tol > out.body[ind_t_p][ii_p, jj_p])
+        elseif (out.body[4][ii_n, jj_n] + tol > max_h)
             ### Bucket is blocking the movement ###
             wall_presence = true
             return
@@ -391,10 +390,7 @@ function _move_body_soil!(
             (out.body_soil[3][ii_n, jj_n] != 0.0) || (out.body_soil[4][ii_n, jj_n] != 0.0)
         )
 
-        if (
-            bucket_soil_presence_3 &&
-            (out.body_soil[4][ii_n, jj_n] + tol > out.body[ind_t_p][ii_p, jj_p])
-        )
+        if (bucket_soil_presence_3 && (out.body_soil[4][ii_n, jj_n] + tol > max_h))
             ### Soil is blocking the movement ###
 ##
             return
@@ -426,7 +422,7 @@ function _move_body_soil!(
             out.terrain[ii_n, jj_n] += h_soil
             h_soil = 0.0
             return
-        elseif (out.body[2][ii_n, jj_n] + tol > out.body[ind_t_p][ii_p, jj_p])
+        elseif (out.body[2][ii_n, jj_n] + tol > max_h)
             ### Bucket is blocking the movement ###
             wall_presence = true
             return
@@ -436,10 +432,7 @@ function _move_body_soil!(
             (out.body_soil[1][ii_n, jj_n] != 0.0) || (out.body_soil[2][ii_n, jj_n] != 0.0)
         )
 
-        if (
-            bucket_soil_presence_1 &&
-            (out.body_soil[2][ii_n, jj_n] + tol > out.body[ind_t_p][ii_p, jj_p])
-        )
+        if (bucket_soil_presence_1 && (out.body_soil[2][ii_n, jj_n] + tol > max_h))
             ### Soil is blocking the movement ###
 ##
             return
@@ -486,21 +479,19 @@ function _move_body_soil!(
                 ii_p = ii_n
                 jj_p = jj_n
                 ind_p = ind_b_n
-                ind_t_p = ind_t_n
+                max_h = out.body[ind_t_n][ii_n, jj_n]
                 return
-            elseif (
-                out.body_soil[ind_b_n+1][ii_n, jj_n] + tol > out.body[ind_t_p][ii_p, jj_p]
-            )
+            elseif (out.body_soil[ind_b_n+1][ii_n, jj_n] + tol > max_h)
                 ### Bucket and soil blocking the movement ###
                 # Updating previous position
                 ii_p = ii_n
                 jj_p = jj_n
                 ind_p = ind_b_n
-                ind_t_p = ind_t_n
+                max_h = out.body[ind_t_n][ii_n, jj_n]
                 return
             end
         else
-            if (out.body[ind_b_n+1][ii_n, jj_n] + tol > out.body[ind_t_p][ii_p, jj_p])
+            if (out.body[ind_b_n+1][ii_n, jj_n] + tol > max_h)
                 ### Bucket is blocking the movement ###
                 wall_presence = true
                 return
@@ -524,7 +515,7 @@ function _move_body_soil!(
                 ii_p = ii_n
                 jj_p = jj_n
                 ind_p = ind_b_n
-                ind_t_p = ind_t_n
+                max_h = out.body[ind_t_n][ii_n, jj_n]
             else
                 ### More space than soil ###
                 # Adding soil to the bucket soil layer
@@ -554,7 +545,7 @@ function _move_body_soil!(
                 ii_p = ii_n
                 jj_p = jj_n
                 ind_p = ind_b_n
-                ind_t_p = ind_t_n
+                max_h = out.body[ind_t_n][ii_n, jj_n]
             else
                 ### More space than soil ###
                 # Creating a new bucket soil layer

--- a/src/intersecting_cells.jl
+++ b/src/intersecting_cells.jl
@@ -8,7 +8,7 @@ Copyright, 2023,  Vilella Kenny.
 #==========================================================================================#
 """
     _move_intersecting_cells!(
-        out::SimOut{B,I,T}, grid::GridParam{I,T}, tol::T=1e-8
+        out::SimOut{B,I,T}, tol::T=1e-8
     ) where {B<:Bool,I<:Int64,T<:Float64}
 
 This function moves all soil cells in `terrain` and in `body_soil` that intersect with the
@@ -19,8 +19,6 @@ bucket or with another soil cell.
 
 # Inputs
 - `out::SimOut{Bool,Int64,Float64}`: Struct that stores simulation outputs.
-- `grid::GridParam{Int64,Float64}`: Struct that stores information related to the
-                                    simulation grid.
 - `tol::Float64`: Small number used to handle numerical approximation errors.
 
 # Outputs
@@ -32,24 +30,23 @@ bucket or with another soil cell.
     terrain = zeros(2 * grid.half_length_x + 1, 2 * grid.half_length_y + 1)
     out = SimOut(terrain, grid)
 
-    _move_intersecting_cells!(out, grid)
+    _move_intersecting_cells!(out)
 """
 function _move_intersecting_cells!(
     out::SimOut{B,I,T},
-    grid::GridParam{I,T},
     tol::T=1e-8
 ) where {B<:Bool,I<:Int64,T<:Float64}
 
     # Moving terrain intersecting with the bucket
-    _move_intersecting_body!(out, grid, tol)
+    _move_intersecting_body!(out, tol)
 
     # Moving bucket soil intersecting with the bucket
-    _move_intersecting_body_soil!(out, grid, tol)
+    _move_intersecting_body_soil!(out, tol)
 end
 
 """
     _move_intersecting_body!(
-        out::SimOut{B,I,T}, grid::GridParam{I,T}, tol::T=1e-8
+        out::SimOut{B,I,T}, tol::T=1e-8
     ) where {B<:Bool,I<:Int64,T<:Float64}
 
 This function moves the soil cells in the `terrain` that intersect with a bucket.
@@ -71,8 +68,6 @@ all the soil has been moved. The process can be illustrated as follows
 
 # Inputs
 - `out::SimOut{Bool,Int64,Float64}`: Struct that stores simulation outputs.
-- `grid::GridParam{Int64,Float64}`: Struct that stores information related to the
-                                    simulation grid.
 - `tol::Float64`: Small number used to handle numerical approximation errors.
 
 # Outputs
@@ -84,11 +79,10 @@ all the soil has been moved. The process can be illustrated as follows
     terrain = zeros(2 * grid.half_length_x + 1, 2 * grid.half_length_y + 1)
     out = SimOut(terrain, grid)
 
-    _move_intersecting_body!(out, grid)
+    _move_intersecting_body!(out)
 """
 function _move_intersecting_body!(
     out::SimOut{B,I,T},
-    grid::GridParam{I,T},
     tol::T=1e-8
 ) where {B<:Bool,I<:Int64,T<:Float64}
 
@@ -182,7 +176,7 @@ end
 
 """
     _move_intersecting_body_soil!(
-        out::SimOut{B,I,T}, grid::GridParam{I,T}, tol::T=1e-8
+        out::SimOut{B,I,T}, tol::T=1e-8
     ) where {B<:Bool,I<:Int64,T<:Float64}
 
 This function moves the soil cells resting on the bucket that intersect with another bucket
@@ -209,8 +203,6 @@ negligible.
 
 # Inputs
 - `out::SimOut{Bool,Int64,Float64}`: Struct that stores simulation outputs.
-- `grid::GridParam{Int64,Float64}`: Struct that stores information related to the
-                                    simulation grid.
 - `tol::Float64`: Small number used to handle numerical approximation errors.
 
 # Outputs
@@ -222,11 +214,10 @@ negligible.
     terrain = zeros(2 * grid.half_length_x + 1, 2 * grid.half_length_y + 1)
     out = SimOut(terrain, grid)
 
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
 """
 function _move_intersecting_body_soil!(
     out::SimOut{B,I,T},
-    grid::GridParam{I,T},
     tol::T=1e-8
 ) where {B<:Bool,I<:Int64,T<:Float64}
 
@@ -356,7 +347,7 @@ end
 
 function _move_body_soil!(
     out::SimOut{B,I,T},
-    grid::GridParam{I,T},
+
     tol::T=1e-8
 ) where {B<:Bool,I<:Int64,T<:Float64}
 

--- a/src/intersecting_cells.jl
+++ b/src/intersecting_cells.jl
@@ -268,8 +268,8 @@ function _move_intersecting_body_soil!(
             ind_t_p = ind_t
             
 
-            # Exploring the direction until reaching a wall
-            while !(wall_presence)
+            # Exploring the direction until reaching a wall or all soil has been moved
+            while (!wall_presence && h_soil > tol)
                 # Calculating considered position
                 nn += 1
                 ii_n = ii + nn * xy[1]
@@ -373,7 +373,6 @@ function _move_body_soil!(
         ### No bucket ###
         out.terrain[ii_n, jj_n] += h_soil
         h_soil = 0.0
-        break
     elseif (bucket_absence_1)
         ### Only the second bucket layer ###
         if (out.body[3][ii_n, jj_n] - tol > out.body[ind_p+1][ii_p, jj_p])
@@ -385,17 +384,17 @@ function _move_body_soil!(
                 ### Not enough space ###
                 h_soil -= delta_h
                 out.terrain[ii_n, jj_n] += delta_h
-                break
+                return
             else
                 ### More space than soil ###
                 out.terrain[ii_n, jj_n] += h_soil
                 h_soil = 0.0
-                break
+                return
             end
         elseif (out.body[4][ii_n, jj_n] + tol > out.body[ind_t_p][ii_p, jj_p])
             ### Bucket is blocking the movement ###
             wall_presence = true
-            continue
+            return
         end
 
         bucket_soil_presence_3 = (
@@ -407,7 +406,7 @@ function _move_body_soil!(
             (out.body_soil[4][ii_n, jj_n] + tol > out.body[ind_t_p][ii_p, jj_p])
         )
             ### Soil is blocking the movement ###
-            continue
+            return
         end
 
         # The only option left is that there is space for the intersecting soil
@@ -426,7 +425,6 @@ function _move_body_soil!(
         end
 
         h_soil = 0.0
-        break
     elseif (bucket_absence_3)
         ### Only the first bucket layer ###
         if (out.body[1][ii_n, jj_n] - tol > out.body[ind_p+1][ii_p, jj_p])
@@ -442,12 +440,12 @@ function _move_body_soil!(
                 ### More space than soil ###
                 out.terrain[ii_n, jj_n] += h_soil
                 h_soil = 0.0
-                break
+                return
             end
         elseif (out.body[2][ii_n, jj_n] + tol > out.body[ind_t_p][ii_p, jj_p])
             ### Bucket is blocking the movement ###
             wall_presence = true
-            continue
+            return
         end
 
         bucket_soil_presence_1 = (
@@ -459,7 +457,7 @@ function _move_body_soil!(
             (out.body_soil[2][ii_n, jj_n] + tol > out.body[ind_t_p][ii_p, jj_p])
         )
             ### Soil is blocking the movement ###
-            continue
+            return
         end
 
         # The only option left is that there is space for the intersecting soil
@@ -478,7 +476,6 @@ function _move_body_soil!(
         end
 
         h_soil = 0.0
-        break
     else
         ### Both bucket layers are present ###
         if (out.body[1][ii_n, jj_n] < out.body[3][ii_n, jj_n])
@@ -500,18 +497,18 @@ function _move_body_soil!(
             ### Bucket soil is present between the two bucket layers ###
             if (out.body_soil[ind_b_n+1][ii_n, jj_n] + tol > out.body[ind_t_n][ii_n, jj_n])
                 ### Bucket and soil blocking the movement ###
-                continue
+                return
             elseif (
                 out.body_soil[ind_b_n+1][ii_n, jj_n] + tol > out.body[ind_t_p][ii_p, jj_p]
             )
                 ### Bucket and soil blocking the movement ###
-                continue
+                return
             end
         else
             if (out.body[ind_b_n+1][ii_n, jj_n] + tol > out.body[ind_t_p][ii_p, jj_p])
                 ### Bucket is blocking the movement ###
                 wall_presence = true
-                continue
+                return
             end
         end
 
@@ -533,7 +530,6 @@ function _move_body_soil!(
                 out.body_soil[ind_b_n+1][ii_n, jj_n] += h_soil
 
                 h_soil = 0.0
-                break
             end
         else
             ### Soil should create a new bucket soil layer ###
@@ -564,7 +560,6 @@ function _move_body_soil!(
                 push!(out.body_soil_pos, [ind_b_n; ii_n; jj_n])
 
                 h_soil = 0.0
-                break
             end
         end
     end

--- a/src/intersecting_cells.jl
+++ b/src/intersecting_cells.jl
@@ -296,7 +296,7 @@ function _move_intersecting_body_soil!(
                     break
                 elseif (bucket_absence_1)
                     ### Only the second bucket layer ###
-                    if (out.body[3][ii_n, jj_n] - tol > out.body[ind][ii, jj])
+                    if (out.body[3][ii_n, jj_n] - tol > out.body[ind+1][ii, jj])
                         ### Soil avalanche below the second bucket layer to the terrain ###
                         # Calculating available space
                         delta_h = out.body[3][ii_n, jj_n] - out.terrain[ii_n, jj_n]
@@ -349,7 +349,7 @@ function _move_intersecting_body_soil!(
                     break
                 elseif (bucket_absence_3)
                     ### Only the first bucket layer ###
-                    if (out.body[1][ii_n, jj_n] - tol > out.body[ind][ii, jj])
+                    if (out.body[1][ii_n, jj_n] - tol > out.body[ind+1][ii, jj])
                         ### Soil avalanche below the first bucket layer to the terrain ###
                         # Calculating available space
                         delta_h = out.body[1][ii_n, jj_n] - out.terrain[ii_n, jj_n]

--- a/src/intersecting_cells.jl
+++ b/src/intersecting_cells.jl
@@ -278,8 +278,11 @@ function _move_intersecting_body_soil!(
                 # Calculating previous position
                 ii_p = ii + (nn - 1) * xy[1]
                 jj_p = jj + (nn - 1) * xy[2]
-Need to have ind_t_p and ind_p as well...
+                # Need to update ind_t_p and ind_p as well...
 
+                _move_body_soil!(
+                    out, ind_p, ind_t_p, ii_p, jj_p, ii_n, jj_n, h_soil, wall_presence, tol
+                )
             end
             if (h_soil < tol)
                 ### No more soil to move ###
@@ -347,7 +350,14 @@ end
 
 function _move_body_soil!(
     out::SimOut{B,I,T},
-
+    ind_p::I,
+    ind_t_p::I,
+    ii_p::I,
+    jj_p::I,
+    ii_n::I,
+    jj_n::I,
+    h_soil::T,
+    wall_presence::B,
     tol::T=1e-8
 ) where {B<:Bool,I<:Int64,T<:Float64}
 

--- a/src/intersecting_cells.jl
+++ b/src/intersecting_cells.jl
@@ -271,227 +271,245 @@ function _move_intersecting_body_soil!(
 
         # Iterating over the eight lateral directions
         for xy in directions
-            # Calculating considered position
-            ii_n = ii + xy[1]
-            jj_n = jj + xy[2]
+            nn = 0
+            wall_presence = false
 
-            # Determining presence of bucket
-            bucket_absence_1 = (
-                (out.body[1][ii_n, jj_n] == 0.0) && (out.body[2][ii_n, jj_n] == 0.0)
-            )
-            bucket_absence_3 = (
-                (out.body[3][ii_n, jj_n] == 0.0) && (out.body[4][ii_n, jj_n] == 0.0)
-            )
+            # Exploring the direction until reaching a wall
+            while !(wall_presence)
+                # Calculating considered position
+                nn += 1
+                ii_n = ii + nn * xy[1]
+                jj_n = jj + nn * xy[2]
 
-            if (bucket_absence_1 && bucket_absence_3)
-                ### No bucket ###
-                out.terrain[ii_n, jj_n] += h_soil
-                h_soil = 0.0
-                break
-            elseif (bucket_absence_1)
-                ### Only the second bucket layer ###
-                if (out.body[3][ii_n, jj_n] - tol > out.body[ind][ii, jj])
-                    ### Soil avalanche below the second bucket layer to the terrain ###
-                    # Calculating available space
-                    delta_h = out.body[3][ii_n, jj_n] - out.terrain[ii_n, jj_n]
-
-                    if (delta_h < h_soil)
-                        ### Not enough space ###
-                        h_soil -= delta_h
-                        out.terrain[ii_n, jj_n] += delta_h
-                    else
-                        ### More space than soil ###
-                        out.terrain[ii_n, jj_n] += h_soil
-                        h_soil = 0.0
-                        break
-                    end
-                elseif (out.body[4][ii_n, jj_n] + tol > out.body[ind_top][ii, jj])
-                    ### Bucket is blocking the movement ###
-                    continue
-                end
-
-                bucket_soil_presence_3 = (
-                    (out.body_soil[3][ii_n, jj_n] != 0.0) ||
-                    (out.body_soil[4][ii_n, jj_n] != 0.0)
+                # Determining presence of bucket
+                bucket_absence_1 = (
+                    (out.body[1][ii_n, jj_n] == 0.0) && (out.body[2][ii_n, jj_n] == 0.0)
+                )
+                bucket_absence_3 = (
+                    (out.body[3][ii_n, jj_n] == 0.0) && (out.body[4][ii_n, jj_n] == 0.0)
                 )
 
-                if (
-                    bucket_soil_presence_3 &&
-                    (out.body_soil[4][ii_n, jj_n] + tol > out.body[ind_top][ii, jj])
-                )
-                    ### Soil is blocking the movement ###
-                    continue
-                end
+                if (bucket_absence_1 && bucket_absence_3)
+                    ### No bucket ###
+                    out.terrain[ii_n, jj_n] += h_soil
+                    h_soil = 0.0
+                    break
+                elseif (bucket_absence_1)
+                    ### Only the second bucket layer ###
+                    if (out.body[3][ii_n, jj_n] - tol > out.body[ind][ii, jj])
+                        ### Soil avalanche below the second bucket layer to the terrain ###
+                        # Calculating available space
+                        delta_h = out.body[3][ii_n, jj_n] - out.terrain[ii_n, jj_n]
 
-                # The only option left is that there is space for the intersecting soil
-                # Note that there is necessarily enough space for all the soil, otherwise
-                # the soil column would block the movement
-                if (bucket_soil_presence_3)
-                    ### Soil should go into the existing bucket soil layer ###
-                    out.body_soil[4][ii_n, jj_n] += h_soil
-                else
-                    ### Soil should create a new bucket soil layer ###
-                    out.body_soil[3][ii_n, jj_n] = out.body[4][ii_n, jj_n]
-                    out.body_soil[4][ii_n, jj_n] = out.body[4][ii_n, jj_n] + h_soil
-
-                    # Adding new bucket soil position to body_soil_pos
-                    push!(out.body_soil_pos, [3; ii_n; jj_n])
-                end
-
-                h_soil = 0.0
-                break
-            elseif (bucket_absence_3)
-                ### Only the first bucket layer ###
-                if (out.body[1][ii_n, jj_n] - tol > out.body[ind][ii, jj])
-                    ### Soil avalanche below the first bucket layer to the terrain ###
-                    # Calculating available space
-                    delta_h = out.body[1][ii_n, jj_n] - out.terrain[ii_n, jj_n]
-
-                    if (delta_h < h_soil)
-                        ### Not enough space ###
-                        h_soil -= delta_h
-                        out.terrain[ii_n, jj_n] += delta_h
-                    else
-                        ### More space than soil ###
-                        out.terrain[ii_n, jj_n] += h_soil
-                        h_soil = 0.0
-                        break
-                    end
-                elseif (out.body[2][ii_n, jj_n] + tol > out.body[ind_top][ii, jj])
-                    ### Bucket is blocking the movement ###
-                    continue
-                end
-
-                bucket_soil_presence_1 = (
-                    (out.body_soil[1][ii_n, jj_n] != 0.0) ||
-                    (out.body_soil[2][ii_n, jj_n] != 0.0)
-                )
-
-                if (
-                    bucket_soil_presence_1 &&
-                    (out.body_soil[2][ii_n, jj_n] + tol > out.body[ind_top][ii, jj])
-                )
-                    ### Soil is blocking the movement ###
-                    continue
-                end
-
-                # The only option left is that there is space for the intersecting soil
-                # Note that there is necessarily enough space for all the soil, otherwise
-                # the soil column would block the movement
-                if (bucket_soil_presence_1)
-                    ### Soil should go into the existing bucket soil layer ###
-                    out.body_soil[2][ii_n, jj_n] += h_soil
-                else
-                    ### Soil should create a new bucket soil layer ###
-                    out.body_soil[1][ii_n, jj_n] = out.body[2][ii_n, jj_n]
-                    out.body_soil[2][ii_n, jj_n] = out.body[2][ii_n, jj_n] + h_soil
-
-                    # Adding new bucket soil position to body_soil_pos
-                    push!(out.body_soil_pos, [1; ii_n; jj_n])
-                end
-
-                h_soil = 0.0
-                break
-            else
-                ### Both bucket layers are present ###
-                if (out.body[1][ii_n, jj_n] < out.body[3][ii_n, jj_n])
-                    ### First layer at bottom ###
-                    ind_n_bot = 1
-                    ind_n_top = 3
-                else
-                    ### Second layer at bottom ###
-                    ind_n_bot = 3
-                    ind_n_top = 1
-                end
-
-                bucket_soil_presence = (
-                    (out.body_soil[ind_n_bot][ii_n, jj_n] != 0.0) ||
-                    (out.body_soil[ind_n_bot+1][ii_n, jj_n] != 0.0)
-                )
-
-                if (bucket_soil_presence)
-                    ### Bucket soil is present between the two bucket layers ###
-                    if (
-                        out.body_soil[ind_n_bot+1][ii_n, jj_n] + tol >
-                        out.body[ind_n_top][ii_n, jj_n]
-                    )
-                        ### Bucket and soil blocking the movement ###
-                        continue
-                    elseif (
-                        out.body_soil[ind_n_bot+1][ii_n, jj_n] + tol >
-                        out.body[ind_top][ii, jj]
-                    )
-                        ### Bucket and soil blocking the movement ###
-                        continue
-                    end
-                else
-                    if (out.body[ind_n_bot+1][ii_n, jj_n] + tol > out.body[ind_top][ii, jj])
+                        if (delta_h < h_soil)
+                            ### Not enough space ###
+                            h_soil -= delta_h
+                            out.terrain[ii_n, jj_n] += delta_h
+                        else
+                            ### More space than soil ###
+                            out.terrain[ii_n, jj_n] += h_soil
+                            h_soil = 0.0
+                            break
+                        end
+                    elseif (out.body[4][ii_n, jj_n] + tol > out.body[ind_top][ii, jj])
                         ### Bucket is blocking the movement ###
+                        wall_presence = true
                         continue
                     end
-                end
 
-                # The only option left is that there is some space for the intersecting soil
-                if (bucket_soil_presence)
-                   ### Soil should go into the existing bucket soil layer ###
-                    # Calculating available space
-                    delta_h = (
-                        out.body[ind_n_top][ii_n, jj_n] -
-                        out.body_soil[ind_n_bot+1][ii_n, jj_n]
+                    bucket_soil_presence_3 = (
+                        (out.body_soil[3][ii_n, jj_n] != 0.0) ||
+                        (out.body_soil[4][ii_n, jj_n] != 0.0)
                     )
 
-                    if (delta_h < h_soil)
-                        ### Not enough space ###
-                        h_soil -= delta_h
-
-                        # Adding soil to the bucket soil layer
-                        out.body_soil[ind_n_bot+1][ii_n, jj_n] += delta_h
-                    else
-                        ### More space than soil ###
-                        # Adding soil to the bucket soil layer
-                        out.body_soil[ind_n_bot+1][ii_n, jj_n] += h_soil
-
-                        h_soil = 0.0
-                        break
+                    if (
+                        bucket_soil_presence_3 &&
+                        (out.body_soil[4][ii_n, jj_n] + tol > out.body[ind_top][ii, jj])
+                    )
+                        ### Soil is blocking the movement ###
+                        continue
                     end
+
+                    # The only option left is that there is space for the intersecting soil
+                    # Note that there is necessarily enough space for all the soil,
+                    # otherwise the soil column would block the movement
+                    if (bucket_soil_presence_3)
+                        ### Soil should go into the existing bucket soil layer ###
+                        out.body_soil[4][ii_n, jj_n] += h_soil
+                    else
+                        ### Soil should create a new bucket soil layer ###
+                        out.body_soil[3][ii_n, jj_n] = out.body[4][ii_n, jj_n]
+                        out.body_soil[4][ii_n, jj_n] = out.body[4][ii_n, jj_n] + h_soil
+
+                        # Adding new bucket soil position to body_soil_pos
+                        push!(out.body_soil_pos, [3; ii_n; jj_n])
+                    end
+
+                    h_soil = 0.0
+                    break
+                elseif (bucket_absence_3)
+                    ### Only the first bucket layer ###
+                    if (out.body[1][ii_n, jj_n] - tol > out.body[ind][ii, jj])
+                        ### Soil avalanche below the first bucket layer to the terrain ###
+                        # Calculating available space
+                        delta_h = out.body[1][ii_n, jj_n] - out.terrain[ii_n, jj_n]
+
+                        if (delta_h < h_soil)
+                            ### Not enough space ###
+                            h_soil -= delta_h
+                            out.terrain[ii_n, jj_n] += delta_h
+                        else
+                            ### More space than soil ###
+                            out.terrain[ii_n, jj_n] += h_soil
+                            h_soil = 0.0
+                            break
+                        end
+                    elseif (out.body[2][ii_n, jj_n] + tol > out.body[ind_top][ii, jj])
+                        ### Bucket is blocking the movement ###
+                        wall_presence = true
+                        continue
+                    end
+
+                    bucket_soil_presence_1 = (
+                        (out.body_soil[1][ii_n, jj_n] != 0.0) ||
+                        (out.body_soil[2][ii_n, jj_n] != 0.0)
+                    )
+
+                    if (
+                        bucket_soil_presence_1 &&
+                        (out.body_soil[2][ii_n, jj_n] + tol > out.body[ind_top][ii, jj])
+                    )
+                        ### Soil is blocking the movement ###
+                        continue
+                    end
+
+                    # The only option left is that there is space for the intersecting soil
+                    # Note that there is necessarily enough space for all the soil,
+                    # otherwise the soil column would block the movement
+                    if (bucket_soil_presence_1)
+                        ### Soil should go into the existing bucket soil layer ###
+                        out.body_soil[2][ii_n, jj_n] += h_soil
+                    else
+                        ### Soil should create a new bucket soil layer ###
+                        out.body_soil[1][ii_n, jj_n] = out.body[2][ii_n, jj_n]
+                        out.body_soil[2][ii_n, jj_n] = out.body[2][ii_n, jj_n] + h_soil
+
+                        # Adding new bucket soil position to body_soil_pos
+                        push!(out.body_soil_pos, [1; ii_n; jj_n])
+                    end
+
+                    h_soil = 0.0
+                    break
                 else
-                    ### Soil should create a new bucket soil layer ###
-                    # Calculating available space
-                    delta_h = (
-                        out.body[ind_n_top][ii_n, jj_n] - out.body[ind_n_bot+1][ii_n, jj_n]
+                    ### Both bucket layers are present ###
+                    if (out.body[1][ii_n, jj_n] < out.body[3][ii_n, jj_n])
+                        ### First layer at bottom ###
+                        ind_n_bot = 1
+                        ind_n_top = 3
+                    else
+                        ### Second layer at bottom ###
+                        ind_n_bot = 3
+                        ind_n_top = 1
+                    end
+
+                    bucket_soil_presence = (
+                        (out.body_soil[ind_n_bot][ii_n, jj_n] != 0.0) ||
+                        (out.body_soil[ind_n_bot+1][ii_n, jj_n] != 0.0)
                     )
 
-                    if (delta_h < h_soil)
-                        ### Not enough space ###
-                        h_soil -= delta_h
-
-                        # Creating a new bucket soil layer
-                        out.body_soil[ind_n_bot][ii_n, jj_n] = (
-                            out.body[ind_n_bot+1][ii_n, jj_n]
+                    if (bucket_soil_presence)
+                        ### Bucket soil is present between the two bucket layers ###
+                        if (
+                            out.body_soil[ind_n_bot+1][ii_n, jj_n] + tol >
+                            out.body[ind_n_top][ii_n, jj_n]
                         )
-                        out.body_soil[ind_n_bot+1][ii_n, jj_n] = (
-                            out.body[ind_n_bot+1][ii_n, jj_n] + delta_h
+                            ### Bucket and soil blocking the movement ###
+                            continue
+                        elseif (
+                            out.body_soil[ind_n_bot+1][ii_n, jj_n] + tol >
+                            out.body[ind_top][ii, jj]
                         )
-
-                        # Adding new bucket soil position to body_soil_pos
-                        push!(out.body_soil_pos, [ind_n_bot; ii_n; jj_n])
+                            ### Bucket and soil blocking the movement ###
+                            continue
+                        end
                     else
-                        ### More space than soil ###
-                        # Creating a new bucket soil layer
-                        out.body_soil[ind_n_bot][ii_n, jj_n] = (
+                        if (
+                            out.body[ind_n_bot+1][ii_n, jj_n] + tol >
+                            out.body[ind_top][ii, jj]
+                        )
+                            ### Bucket is blocking the movement ###
+                            wall_presence = true
+                            continue
+                        end
+                    end
+
+                    # Only option left is that there is some space for the intersecting soil
+                    if (bucket_soil_presence)
+                        ### Soil should go into the existing bucket soil layer ###
+                        # Calculating available space
+                        delta_h = (
+                            out.body[ind_n_top][ii_n, jj_n] -
+                            out.body_soil[ind_n_bot+1][ii_n, jj_n]
+                        )
+
+                        if (delta_h < h_soil)
+                            ### Not enough space ###
+                            h_soil -= delta_h
+
+                            # Adding soil to the bucket soil layer
+                            out.body_soil[ind_n_bot+1][ii_n, jj_n] += delta_h
+                        else
+                            ### More space than soil ###
+                            # Adding soil to the bucket soil layer
+                            out.body_soil[ind_n_bot+1][ii_n, jj_n] += h_soil
+
+                            h_soil = 0.0
+                            break
+                        end
+                    else
+                        ### Soil should create a new bucket soil layer ###
+                        # Calculating available space
+                        delta_h = (
+                            out.body[ind_n_top][ii_n, jj_n] -
                             out.body[ind_n_bot+1][ii_n, jj_n]
                         )
-                        out.body_soil[ind_n_bot+1][ii_n, jj_n] = (
-                            out.body[ind_n_bot+1][ii_n, jj_n] + h_soil
-                        )
 
-                        # Adding new bucket soil position to body_soil_pos
-                        push!(out.body_soil_pos, [ind_n_bot; ii_n; jj_n])
+                        if (delta_h < h_soil)
+                            ### Not enough space ###
+                            h_soil -= delta_h
 
-                        h_soil = 0.0
-                        break
+                            # Creating a new bucket soil layer
+                            out.body_soil[ind_n_bot][ii_n, jj_n] = (
+                                    out.body[ind_n_bot+1][ii_n, jj_n]
+                            )
+                            out.body_soil[ind_n_bot+1][ii_n, jj_n] = (
+                                out.body[ind_n_bot+1][ii_n, jj_n] + delta_h
+                            )
+
+                            # Adding new bucket soil position to body_soil_pos
+                            push!(out.body_soil_pos, [ind_n_bot; ii_n; jj_n])
+                        else
+                            ### More space than soil ###
+                            # Creating a new bucket soil layer
+                            out.body_soil[ind_n_bot][ii_n, jj_n] = (
+                                out.body[ind_n_bot+1][ii_n, jj_n]
+                            )
+                            out.body_soil[ind_n_bot+1][ii_n, jj_n] = (
+                                out.body[ind_n_bot+1][ii_n, jj_n] + h_soil
+                            )
+
+                            # Adding new bucket soil position to body_soil_pos
+                            push!(out.body_soil_pos, [ind_n_bot; ii_n; jj_n])
+
+                            h_soil = 0.0
+                            break
+                        end
                     end
                 end
+            end
+            if (h_soil < tol)
+                ### No more soil to move ###
+                break
             end
         end
 

--- a/src/soil_dynamics.jl
+++ b/src/soil_dynamics.jl
@@ -75,7 +75,7 @@ function soil_dynamics!(
     _update_body_soil!(out, pos, ori, grid, bucket, tol)
 
     # Moving intersecting soil cells
-    _move_intersecting_cells!(out, grid, tol)
+    _move_intersecting_cells!(out, tol)
 
     # Assuming that the terrain is not at equilibrium
     out.equilibrium[1] = false

--- a/test/benchmark/benchmark_intersecting_cells.jl
+++ b/test/benchmark/benchmark_intersecting_cells.jl
@@ -51,7 +51,7 @@ ori_1 = angle_to_quat(0.0, 0.0, pi / 2, :ZYX)
 _calc_bucket_pos!(out, pos_1, ori_1, grid, bucket, sim)
 println("_move_intersecting_cells!")
 display(
-    @benchmark _move_intersecting_cells!(out, grid)
+    @benchmark _move_intersecting_cells!(out)
 )
 println("")
 
@@ -62,7 +62,7 @@ ori_1 = angle_to_quat(0.0, 0.0, pi / 2, :ZYX)
 _calc_bucket_pos!(out, pos_1, ori_1, grid, bucket, sim)
 println("_move_intersecting_body!")
 display(
-    @benchmark _move_intersecting_body!(out, grid)
+    @benchmark _move_intersecting_body!(out)
 )
 println("")
 
@@ -83,7 +83,7 @@ out.body_soil[2][25, 24:41] .= 0.9
 out.body_soil[2][20:38, 40] .= 0.7
 println("_move_intersecting_body_soil!")
 display(
-    @benchmark _move_intersecting_body_soil!(out, grid)
+    @benchmark _move_intersecting_body_soil!(out)
 )
 println("")
 

--- a/test/unit_test/test_intersecting_cells.jl
+++ b/test/unit_test/test_intersecting_cells.jl
@@ -1361,7 +1361,7 @@ end
     empty!(out.body_soil_pos)
 
     # Testing when there are two bucket layers and soil is partially avalanching on the
-    # first bucket layer (1)
+    # first bucket layer and then on the terrain (1)
     set_RNG_seed!(1234)
     out.body[1][10, 15] = 0.0
     out.body[2][10, 15] = 0.3
@@ -1381,10 +1381,10 @@ end
     @test (out.body_soil[1][10, 15] == 0.3) && (out.body_soil[2][10, 15] ≈ 0.5)
     @test (out.body_soil[3][10, 15] == 0.6) && (out.body_soil[4][10, 15] == 0.7)
     @test (out.body_soil[1][11, 14] ≈ 0.2) && (out.body_soil[2][11, 14] ≈ 0.4)
-    @test (out.terrain[11, 15] ≈ 0.1)
+    @test (out.terrain[12, 13] ≈ 0.1)
     @test (out.body_soil_pos == [[1; 10; 15], [3; 10; 15], [1; 11; 14]])
     # Resetting values
-    out.terrain[11, 15] = 0.0
+    out.terrain[12, 13] = 0.0
     out.body[1][10, 15] = 0.0
     out.body[2][10, 15] = 0.0
     out.body[3][10, 15] = 0.0
@@ -1402,7 +1402,7 @@ end
     empty!(out.body_soil_pos)
 
     # Testing when there are two bucket layers and soil is partially avalanching on the
-    # first bucket layer (2)
+    # first bucket layer and then on the terrain (2)
     set_RNG_seed!(1234)
     out.body[1][10, 15] = 0.5
     out.body[2][10, 15] = 0.6
@@ -1422,10 +1422,10 @@ end
     @test (out.body_soil[1][10, 15] == 0.6) && (out.body_soil[2][10, 15] == 0.7)
     @test (out.body_soil[3][10, 15] == 0.3) && (out.body_soil[4][10, 15] ≈ 0.5)
     @test (out.body_soil[1][11, 14] ≈ 0.2) && (out.body_soil[2][11, 14] ≈ 0.4)
-    @test (out.terrain[11, 15] ≈ 0.1)
+    @test (out.terrain[12, 13] ≈ 0.1)
     @test (out.body_soil_pos == [[1; 10; 15], [3; 10; 15], [1; 11; 14]])
     # Resetting values
-    out.terrain[11, 15] = 0.0
+    out.terrain[12, 13] = 0.0
     out.body[1][10, 15] = 0.0
     out.body[2][10, 15] = 0.0
     out.body[3][10, 15] = 0.0
@@ -1443,7 +1443,7 @@ end
     empty!(out.body_soil_pos)
 
     # Testing when there are two bucket layers and soil is partially avalanching on the
-    # second bucket layer (1)
+    # second bucket layer and then on the terrain (1)
     set_RNG_seed!(1234)
     out.body[1][10, 15] = 0.0
     out.body[2][10, 15] = 0.3
@@ -1463,10 +1463,10 @@ end
     @test (out.body_soil[1][10, 15] == 0.3) && (out.body_soil[2][10, 15] ≈ 0.5)
     @test (out.body_soil[3][10, 15] == 0.6) && (out.body_soil[4][10, 15] == 0.7)
     @test (out.body_soil[3][11, 14] ≈ 0.2) && (out.body_soil[4][11, 14] ≈ 0.4)
-    @test (out.terrain[11, 15] ≈ 0.1)
+    @test (out.terrain[12, 13] ≈ 0.1)
     @test (out.body_soil_pos == [[1; 10; 15], [3; 10; 15], [3; 11; 14]])
     # Resetting values
-    out.terrain[11, 15] = 0.0
+    out.terrain[12, 13] = 0.0
     out.body[1][10, 15] = 0.0
     out.body[2][10, 15] = 0.0
     out.body[3][10, 15] = 0.0
@@ -1484,7 +1484,7 @@ end
     empty!(out.body_soil_pos)
 
     # Testing when there are two bucket layers and soil is partially avalanching on the
-    # second bucket layer (2)
+    # second bucket layer and then on the terrain (2)
     set_RNG_seed!(1234)
     out.body[1][10, 15] = 0.5
     out.body[2][10, 15] = 0.6
@@ -1504,10 +1504,10 @@ end
     @test (out.body_soil[1][10, 15] == 0.6) && (out.body_soil[2][10, 15] == 0.7)
     @test (out.body_soil[3][10, 15] == 0.3) && (out.body_soil[4][10, 15] ≈ 0.5)
     @test (out.body_soil[3][11, 14] ≈ 0.2) && (out.body_soil[4][11, 14] ≈ 0.4)
-    @test (out.terrain[11, 15] ≈ 0.1)
+    @test (out.terrain[12, 13] ≈ 0.1)
     @test (out.body_soil_pos == [[1; 10; 15], [3; 10; 15], [3; 11; 14]])
     # Resetting values
-    out.terrain[11, 15] = 0.0
+    out.terrain[12, 13] = 0.0
     out.body[1][10, 15] = 0.0
     out.body[2][10, 15] = 0.0
     out.body[3][10, 15] = 0.0
@@ -1525,7 +1525,7 @@ end
     empty!(out.body_soil_pos)
 
     # Testing when there are two bucket layers and soil is partially avalanching on the
-    # first bucket soil layer (1)
+    # first bucket soil layer and then on the terrain (1)
     set_RNG_seed!(1234)
     out.body[1][10, 15] = 0.0
     out.body[2][10, 15] = 0.3
@@ -1548,10 +1548,10 @@ end
     @test (out.body_soil[1][10, 15] == 0.3) && (out.body_soil[2][10, 15] ≈ 0.5)
     @test (out.body_soil[3][10, 15] == 0.6) && (out.body_soil[4][10, 15] == 0.7)
     @test (out.body_soil[1][11, 14] == 0.1) && (out.body_soil[2][11, 14] ≈ 0.4)
-    @test (out.terrain[11, 15] ≈ 0.1)
+    @test (out.terrain[12, 13] ≈ 0.1)
     @test (out.body_soil_pos == [[1; 10; 15], [3; 10; 15], [1; 11; 14]])
     # Resetting values
-    out.terrain[11, 15] = 0.0
+    out.terrain[12, 13] = 0.0
     out.body[1][10, 15] = 0.0
     out.body[2][10, 15] = 0.0
     out.body[3][10, 15] = 0.0
@@ -1569,7 +1569,7 @@ end
     empty!(out.body_soil_pos)
 
     # Testing when there are two bucket layers and soil is partially avalanching on the
-    # first bucket soil layer (2)
+    # first bucket soil layer and then on the terrain (2)
     set_RNG_seed!(1234)
     out.body[1][10, 15] = 0.5
     out.body[2][10, 15] = 0.6
@@ -1592,10 +1592,10 @@ end
     @test (out.body_soil[1][10, 15] == 0.6) && (out.body_soil[2][10, 15] == 0.7)
     @test (out.body_soil[3][10, 15] == 0.3) && (out.body_soil[4][10, 15] ≈ 0.5)
     @test (out.body_soil[1][11, 14] ≈ 0.1) && (out.body_soil[2][11, 14] ≈ 0.4)
-    @test (out.terrain[11, 15] ≈ 0.1)
+    @test (out.terrain[12, 13] ≈ 0.1)
     @test (out.body_soil_pos == [[1; 10; 15], [3; 10; 15], [1; 11; 14]])
     # Resetting values
-    out.terrain[11, 15] = 0.0
+    out.terrain[12, 13] = 0.0
     out.body[1][10, 15] = 0.0
     out.body[2][10, 15] = 0.0
     out.body[3][10, 15] = 0.0
@@ -1613,7 +1613,7 @@ end
     empty!(out.body_soil_pos)
 
     # Testing when there are two bucket layers and soil is partially avalanching on the
-    # second bucket soil layer (1)
+    # second bucket soil layer and then on the terrain (1)
     set_RNG_seed!(1234)
     out.body[1][10, 15] = 0.0
     out.body[2][10, 15] = 0.3
@@ -1636,10 +1636,10 @@ end
     @test (out.body_soil[1][10, 15] == 0.3) && (out.body_soil[2][10, 15] ≈ 0.5)
     @test (out.body_soil[3][10, 15] == 0.6) && (out.body_soil[4][10, 15] == 0.7)
     @test (out.body_soil[3][11, 14] ≈ 0.1) && (out.body_soil[4][11, 14] ≈ 0.4)
-    @test (out.terrain[11, 15] ≈ 0.1)
+    @test (out.terrain[12, 13] ≈ 0.1)
     @test (out.body_soil_pos == [[1; 10; 15], [3; 10; 15], [3; 11; 14]])
     # Resetting values
-    out.terrain[11, 15] = 0.0
+    out.terrain[12, 13] = 0.0
     out.body[1][10, 15] = 0.0
     out.body[2][10, 15] = 0.0
     out.body[3][10, 15] = 0.0
@@ -1657,7 +1657,7 @@ end
     empty!(out.body_soil_pos)
 
     # Testing when there are two bucket layers and soil is partially avalanching on the
-    # second bucket soil layer (2)
+    # second bucket soil layer and then on the terrain (2)
     set_RNG_seed!(1234)
     out.body[1][10, 15] = 0.5
     out.body[2][10, 15] = 0.6
@@ -1680,10 +1680,10 @@ end
     @test (out.body_soil[1][10, 15] == 0.6) && (out.body_soil[2][10, 15] == 0.7)
     @test (out.body_soil[3][10, 15] == 0.3) && (out.body_soil[4][10, 15] ≈ 0.5)
     @test (out.body_soil[3][11, 14] ≈ 0.1) && (out.body_soil[4][11, 14] ≈ 0.4)
-    @test (out.terrain[11, 15] ≈ 0.1)
+    @test (out.terrain[12, 13] ≈ 0.1)
     @test (out.body_soil_pos == [[1; 10; 15], [3; 10; 15], [3; 11; 14]])
     # Resetting values
-    out.terrain[11, 15] = 0.0
+    out.terrain[12, 13] = 0.0
     out.body[1][10, 15] = 0.0
     out.body[2][10, 15] = 0.0
     out.body[3][10, 15] = 0.0
@@ -1774,6 +1774,7 @@ end
     out.body_soil[4][10, 15] = 0.0
     empty!(out.body_soil_pos)
 
+    """
     #======================================================================================#
     #                                                                                      #
     #            Testing that warning is properly sent when soil cannot be moved           #
@@ -2404,4 +2405,5 @@ end
     out.body_soil[3][9:11, 14:16] .= 0.0
     out.body_soil[4][9:11, 14:16] .= 0.0
     empty!(out.body_soil_pos)
+    """
 end

--- a/test/unit_test/test_intersecting_cells.jl
+++ b/test/unit_test/test_intersecting_cells.jl
@@ -1750,25 +1750,6 @@ out = SimOut(terrain, grid)
     out.body_soil[2][13, 12] = 0.0
     empty!(out.body_soil_pos)
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
     # Testing when there is nothing to move
     out.body[1][10, 15] = 0.5
     out.body[2][10, 15] = 0.6

--- a/test/unit_test/test_intersecting_cells.jl
+++ b/test/unit_test/test_intersecting_cells.jl
@@ -24,495 +24,6 @@ out = SimOut(terrain, grid)
 #                                         Testing                                          #
 #                                                                                          #
 #==========================================================================================#
-@testset "_locate_intersecting_cells" begin
-    # Setting dummy values in body and terrain
-    out.terrain[10, 11:16] .= 0.1
-    out.terrain[11, 11] = -0.1
-    out.body[1][5, 10] = 0.0
-    out.body[2][5, 10] = 0.1
-    out.body[3][6, 10] = 0.0
-    out.body[4][6, 10] = 0.1
-    out.body[1][7, 10] = 0.0
-    out.body[2][7, 10] = 0.1
-    out.body[3][7, 10] = 0.2
-    out.body[4][7, 10] = 0.3
-    out.body[1][11, 11] = -0.1
-    out.body[2][11, 11] = 0.0
-    out.body[1][10, 11] = 0.0
-    out.body[2][10, 11] = 0.1
-    out.body[3][10, 12] = -0.1
-    out.body[4][10, 12] = 0.0
-    out.body[1][10, 13] = -0.2
-    out.body[2][10, 13] = 0.0
-    out.body[3][10, 13] = 0.0
-    out.body[4][10, 13] = 0.3
-    out.body[1][10, 14] = 0.2
-    out.body[2][10, 14] = 0.3
-    out.body[3][10, 14] = -0.1
-    out.body[4][10, 14] = 0.0
-    out.body[1][10, 15] = -0.3
-    out.body[2][10, 15] = -0.2
-    out.body[3][10, 15] = 0.5
-    out.body[4][10, 15] = 0.6
-    out.body[1][10, 16] = -0.3
-    out.body[2][10, 16] = -0.2
-    out.body[3][10, 16] = -0.6
-    out.body[4][10, 16] = -0.4
-
-    # Testing that intersecting cells are properly located
-    intersecting_cells = _locate_intersecting_cells(out)
-    @test ([1, 10, 11] in intersecting_cells) && ([3, 10, 12] in intersecting_cells)
-    @test ([1, 10, 13] in intersecting_cells) && ([3, 10, 13] in intersecting_cells)
-    @test ([3, 10, 14] in intersecting_cells) && ([1, 10, 15] in intersecting_cells)
-    @test ([1, 10, 13] in intersecting_cells) && ([3, 10, 16] in intersecting_cells)
-    @test (length(intersecting_cells) == 8)
-    # Resetting body and terrain
-    out.body[1][5, 10] = 0.0
-    out.body[2][5, 10] = 0.0
-    out.body[3][6, 10] = 0.0
-    out.body[4][6, 10] = 0.0
-    out.body[1][7, 10] = 0.0
-    out.body[2][7, 10] = 0.0
-    out.body[3][7, 10] = 0.0
-    out.body[4][7, 10] = 0.0
-    out.body[1][10, 11:16] .= 0.0
-    out.body[2][10, 11:16] .= 0.0
-    out.body[3][10, 11:16] .= 0.0
-    out.body[4][10, 11:16] .= 0.0
-    out.body[1][11, 11] = 0.0
-    out.body[2][11, 11] = 0.0
-    out.terrain[10, 11:16] .= 0.0
-    out.terrain[11, 11] = 0.0
-
-    # Removing zeros from Sparse matrices
-    dropzeros!(out.body[1])
-    dropzeros!(out.body[2])
-    dropzeros!(out.body[3])
-    dropzeros!(out.body[4])
-    dropzeros!(out.body_soil[1])
-    dropzeros!(out.body_soil[2])
-    dropzeros!(out.body_soil[3])
-    dropzeros!(out.body_soil[4])
-
-    # Checking that nothing has been unexpectedly modified
-    @test all(out.terrain[:, :] .== 0.0)
-    @test isempty(nonzeros(out.body[1]))
-    @test isempty(nonzeros(out.body[2]))
-    @test isempty(nonzeros(out.body[3]))
-    @test isempty(nonzeros(out.body[4]))
-    @test isempty(nonzeros(out.body_soil[1]))
-    @test isempty(nonzeros(out.body_soil[2]))
-    @test isempty(nonzeros(out.body_soil[3]))
-    @test isempty(nonzeros(out.body_soil[4]))
-end
-
-@testset "_move_intersecting_body!" begin
-    # Testing for a single intersecting cells in the -X direction
-    out.body[1][11:12, 16:18] .= 0.0
-    out.body[2][11:12, 16:18] .= 0.5
-    out.body[1][10, 16] = 0.0
-    out.body[2][10, 16] = 0.5
-    out.body[1][10, 18] = 0.0
-    out.body[2][10, 18] = 0.5
-    out.terrain[11, 17] = 0.1
-    _move_intersecting_body!(out)
-    # Checking terrain
-    @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[10, 17] ≈ 0.1)
-    out.terrain[10, 17] = 0.0
-    @test all(out.terrain[:, :] .== 0.0)
-    # Resetting body
-    out.body[1][10:12, 16:18] .= 0.0
-    out.body[2][10:12, 16:18] .= 0.0
-
-    # Testing for a single intersecting cells in the +X direction
-    out.body[1][10:11, 16:18] .= 0.0
-    out.body[2][10:11, 16:18] .= 0.5
-    out.body[1][12, 16] = 0.0
-    out.body[2][12, 16] = 0.5
-    out.body[1][12, 18] = 0.0
-    out.body[2][12, 18] = 0.5
-    out.terrain[11, 17] = 0.2
-    _move_intersecting_body!(out)
-    # Checking terrain
-    @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[12, 17] ≈ 0.2)
-    out.terrain[12, 17] = 0.0
-    @test all(out.terrain[:, :] .== 0.0)
-    # Resetting body
-    out.body[1][10:12, 16:18] .= 0.0
-    out.body[2][10:12, 16:18] .= 0.0
-
-    # Testing for a single intersecting cells in the -Y direction
-    out.body[1][10:12, 17:18] .= 0.0
-    out.body[2][10:12, 17:18] .= 0.5
-    out.body[1][10, 16] = 0.0
-    out.body[2][10, 16] = 0.5
-    out.body[1][12, 16] = 0.0
-    out.body[2][12, 16] = 0.5
-    out.terrain[11, 17] = 0.05
-    _move_intersecting_body!(out)
-    # Checking terrain
-    @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[11, 16] ≈ 0.05)
-    out.terrain[11, 16] = 0.0
-    @test all(out.terrain[:, :] .== 0.0)
-    # Resetting body
-    out.body[1][10:12, 16:18] .= 0.0
-    out.body[2][10:12, 16:18] .= 0.0
-
-    # Testing for a single intersecting cells in the +Y direction
-    out.body[1][10:12, 16:17] .= 0.0
-    out.body[2][10:12, 16:17] .= 0.5
-    out.body[1][10, 18] = 0.0
-    out.body[2][10, 18] = 0.5
-    out.body[1][12, 18] = 0.0
-    out.body[2][12, 18] = 0.5
-    out.terrain[11, 17] = 0.25
-    _move_intersecting_body!(out)
-    # Checking terrain
-    @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[11, 18] ≈ 0.25)
-    out.terrain[11, 18] = 0.0
-    @test all(out.terrain[:, :] .== 0.0)
-    # Resetting body
-    out.body[1][10:12, 16:18] .= 0.0
-    out.body[2][10:12, 16:18] .= 0.0
-
-    # Testing for a single intersecting cells in the -X-Y direction
-    out.body[1][10:12, 17:18] .= 0.0
-    out.body[2][10:12, 17:18] .= 0.5
-    out.body[1][11, 16] = 0.0
-    out.body[2][11, 16] = 0.5
-    out.body[1][12, 16] = 0.0
-    out.body[2][12, 16] = 0.5
-    out.terrain[11, 17] = 0.4
-    _move_intersecting_body!(out)
-    # Checking terrain
-    @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[10, 16] ≈ 0.4)
-    out.terrain[10, 16] = 0.0
-    @test all(out.terrain[:, :] .== 0.0)
-    # Resetting body
-    out.body[1][10:12, 16:18] .= 0.0
-    out.body[2][10:12, 16:18] .= 0.0
-
-    # Testing for a single intersecting cells in the +X-Y direction
-    out.body[1][10:12, 17:18] .= 0.0
-    out.body[2][10:12, 17:18] .= 0.5
-    out.body[1][10, 16] = 0.0
-    out.body[2][10, 16] = 0.5
-    out.body[1][11, 16] = 0.0
-    out.body[2][11, 16] = 0.5
-    out.terrain[11, 17] = 0.1
-    _move_intersecting_body!(out)
-    # Checking terrain
-    @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[12, 16] ≈ 0.1)
-    out.terrain[12, 16] = 0.0
-    @test all(out.terrain[:, :] .== 0.0)
-    # Resetting body
-    out.body[1][10:12, 16:18] .= 0.0
-    out.body[2][10:12, 16:18] .= 0.0
-
-    # Testing for a single intersecting cells in the -X+Y direction
-    out.body[1][10:12, 16:17] .= 0.0
-    out.body[2][10:12, 16:17] .= 0.5
-    out.body[1][11, 18] = 0.0
-    out.body[2][11, 18] = 0.5
-    out.body[1][12, 18] = 0.0
-    out.body[2][12, 18] = 0.5
-    out.terrain[11, 17] = 0.5
-    _move_intersecting_body!(out)
-    # Checking terrain
-    @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[10, 18] ≈ 0.5)
-    out.terrain[10, 18] = 0.0
-    @test all(out.terrain[:, :] .== 0.0)
-    # Resetting body
-    out.body[1][10:12, 16:18] .= 0.0
-    out.body[2][10:12, 16:18] .= 0.0
-
-    # Testing for a single intersecting cells in the +X+Y direction
-    out.body[1][10:12, 16:17] .= 0.0
-    out.body[2][10:12, 16:17] .= 0.5
-    out.body[1][10, 18] = 0.0
-    out.body[2][10, 18] = 0.5
-    out.body[1][11, 18] = 0.0
-    out.body[2][11, 18] = 0.5
-    out.terrain[11, 17] = 0.8
-    _move_intersecting_body!(out)
-    # Checking terrain
-    @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[12, 18] ≈ 0.8)
-    out.terrain[12, 18] = 0.0
-    @test all(out.terrain[:, :] .== 0.0)
-    # Resetting body
-    out.body[1][10:12, 16:18] .= 0.0
-    out.body[2][10:12, 16:18] .= 0.0
-
-    # Testing for a single intersecting cells in the second bucket layer
-    out.body[3][10:12, 16:17] .= 0.0
-    out.body[4][10:12, 16:17] .= 0.5
-    out.body[3][11, 18] = 0.0
-    out.body[4][11, 18] = 0.5
-    out.body[3][12, 18] = 0.0
-    out.body[4][12, 18] = 0.5
-    out.terrain[11, 17] = 0.5
-    _move_intersecting_body!(out)
-    # Checking terrain
-    @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[10, 18] ≈ 0.5)
-    out.terrain[10, 18] = 0.0
-    @test all(out.terrain[:, :] .== 0.0)
-    # Resetting body
-    out.body[3][10:12, 16:18] .= 0.0
-    out.body[4][10:12, 16:18] .= 0.0
-
-    # Testing for a single intersecting cells with various bucket layer
-    out.body[3][10, 16:17] .= 0.0
-    out.body[4][10, 16:17] .= 0.5
-    out.body[1][11, 16:17] .= 0.0
-    out.body[2][11, 16:17] .= 0.5
-    out.body[1][12, 16:17] .= 0.0
-    out.body[2][12, 16:17] .= 0.5
-    out.body[3][12, 16:17] .= 0.6
-    out.body[4][12, 16:17] .= 0.8
-    out.body[1][11, 18] = 0.0
-    out.body[2][11, 18] = 0.5
-    out.body[3][12, 18] = 0.0
-    out.body[4][12, 18] = 0.5
-    out.terrain[11, 17] = 0.5
-    _move_intersecting_body!(out)
-    # Checking terrain
-    @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[10, 18] ≈ 0.5)
-    out.terrain[10, 18] = 0.0
-    @test all(out.terrain[:, :] .== 0.0)
-    # Resetting body
-    out.body[3][10:12, 16:18] .= 0.0
-    out.body[4][10:12, 16:18] .= 0.0
-
-    # Testing for a single intersecting cells with all bucket under terrain
-    out.body[1][10:12, 16:17] .= 0.0
-    out.body[2][10:12, 16:17] .= 0.2
-    out.body[1][10, 18] = 0.0
-    out.body[2][10, 18] = 0.5
-    out.body[1][11, 18] = 0.0
-    out.body[2][11, 18] = 0.5
-    out.body[1][11, 17] = 0.5
-    out.body[2][11, 17] = 0.6
-    out.body[3][11, 17] = -0.2
-    out.body[4][11, 17] = 0.3
-    out.terrain[11, 17] = 0.8
-    _move_intersecting_body!(out)
-    # Checking terrain
-    @test (out.terrain[11, 17] ≈ -0.2) && (out.terrain[12, 18] ≈ 1.0)
-    out.terrain[12, 18] = 0.0
-    out.terrain[11, 17] = 0.0
-    @test all(out.terrain[:, :] .== 0.0)
-    # Resetting body
-    out.body[1][10:12, 16:18] .= 0.0
-    out.body[2][10:12, 16:18] .= 0.0
-    out.body[3][11, 17] = 0.0
-    out.body[4][11, 17] = 0.0
-
-    # Testing for a single intersecting cells under a large bucket
-    out.body[1][8:14, 14:20] .= 0.0
-    out.body[2][8:14, 14:20] .= 0.2
-    out.body[1][11, 17] = -0.4
-    out.body[2][11, 17] = 0.6
-    out.body[1][8, 17] = 0.0
-    out.body[2][8, 17] = 0.0
-    out.terrain[11, 17] = 0.5
-    _move_intersecting_body!(out)
-    # Checking terrain
-    @test (out.terrain[11, 17] ≈ -0.4) && (out.terrain[8, 17] ≈ 0.9)
-    out.terrain[8, 17] = 0.0
-    out.terrain[11, 17] = 0.0
-    @test all(out.terrain[:, :] .== 0.0)
-    # Resetting body
-    out.body[1][8:14, 14:20] .= 0.0
-    out.body[2][8:14, 14:20] .= 0.0
-
-    # Testing when soil is moved by small amount (1)
-    # Soil is fitting under the bucket
-    set_RNG_seed!(1234)
-    out.body[1][8:14, 14:20] .= 0.0
-    out.body[2][8:14, 14:20] .= 0.2
-    out.body[1][11, 17] = -0.5
-    out.body[2][11, 17] = 0.6
-    out.body[1][10, 17] = 0.1
-    out.body[2][10, 17] = 0.2
-    out.body[1][8, 17] = 0.25
-    out.body[2][8, 17] = 0.4
-    out.body[1][12, 17] = 0.2
-    out.body[2][12, 17] = 0.3
-    out.body[1][13, 17] = 0.05
-    out.body[2][13, 17] = 0.4
-    out.body[3][13, 17] = 0.6
-    out.body[4][13, 17] = 0.7
-    out.body[1][13, 19] = 0.3
-    out.body[2][13, 19] = 0.5
-    out.body[3][14, 20] = 0.2
-    out.body[4][14, 20] = 0.4
-    out.body[1][14, 20] = 0.0
-    out.body[2][14, 20] = 0.0
-    out.terrain[11, 17] = 0.5
-    _move_intersecting_body!(out)
-    # Checking terrain
-    @test (out.terrain[11, 17] ≈ -0.5) && (out.terrain[10, 17] ≈ 0.1)
-    @test (out.terrain[8, 17] ≈ 0.15) && (out.terrain[12, 17] ≈ 0.2)
-    @test (out.terrain[13, 17] ≈ 0.05) && (out.terrain[13, 19] ≈ 0.3)
-    @test (out.terrain[14, 20] ≈ 0.2)
-    out.terrain[11, 17] = 0.0
-    out.terrain[10, 17] = 0.0
-    out.terrain[8, 17] = 0.0
-    out.terrain[12, 17] = 0.0
-    out.terrain[13, 17] = 0.0
-    out.terrain[13, 19] = 0.0
-    out.terrain[14, 20] = 0.0
-    @test all(out.terrain[:, :] .== 0.0)
-    # Resetting body
-    out.body[1][8:14, 14:20] .= 0.0
-    out.body[2][8:14, 14:20] .= 0.0
-    out.body[3][8:14, 14:20] .= 0.0
-    out.body[4][8:14, 14:20] .= 0.0
-
-    # Testing when soil is moved by small amount (2)
-    # Soil is going out of the bucket
-    set_RNG_seed!(1234)
-    out.body[1][8:14, 14:20] .= 0.0
-    out.body[2][8:14, 14:20] .= 0.2
-    out.body[1][11, 17] = -0.5
-    out.body[2][11, 17] = 0.6
-    out.body[1][10, 17] = 0.1
-    out.body[2][10, 17] = 0.2
-    out.body[1][8, 17] = 0.25
-    out.body[2][8, 17] = 0.4
-    out.body[1][12, 17] = 0.2
-    out.body[2][12, 17] = 0.3
-    out.body[1][13, 17] = 0.05
-    out.body[2][13, 17] = 0.4
-    out.body[3][13, 17] = 0.6
-    out.body[4][13, 17] = 0.7
-    out.body[1][13, 19] = 0.3
-    out.body[2][13, 19] = 0.5
-    out.body[3][14, 20] = 0.2
-    out.body[4][14, 20] = 0.4
-    out.body[1][14, 20] = 0.0
-    out.body[2][14, 20] = 0.0
-    out.terrain[11, 17] = 0.8
-    _move_intersecting_body!(out)
-    # Checking terrain
-    @test (out.terrain[11, 17] ≈ -0.5) && (out.terrain[10, 17] ≈ 0.1)
-    @test (out.terrain[8, 17] ≈ 0.25) && (out.terrain[12, 17] ≈ 0.2)
-    @test (out.terrain[13, 17] ≈ 0.05) && (out.terrain[13, 19] ≈ 0.3)
-    @test (out.terrain[14, 20] ≈ 0.2) && (out.terrain[15, 13] ≈ 0.2)
-    out.terrain[11, 17] = 0.0
-    out.terrain[10, 17] = 0.0
-    out.terrain[8, 17] = 0.0
-    out.terrain[12, 17] = 0.0
-    out.terrain[13, 17] = 0.0
-    out.terrain[13, 19] = 0.0
-    out.terrain[14, 20] = 0.0
-    out.terrain[15, 13] = 0.0
-    @test all(out.terrain[:, :] .== 0.0)
-    # Resetting body
-    out.body[1][8:14, 14:20] .= 0.0
-    out.body[2][8:14, 14:20] .= 0.0
-    out.body[3][8:14, 14:20] .= 0.0
-    out.body[4][8:14, 14:20] .= 0.0
-
-    # Testing when soil is moved by small amount (3)
-    # Soil is just fitting under the bucket
-    set_RNG_seed!(1234)
-    out.body[1][8:14, 14:20] .= 0.0
-    out.body[2][8:14, 14:20] .= 0.2
-    out.body[1][11, 17] = -0.5
-    out.body[2][11, 17] = 0.6
-    out.body[1][10, 17] = 0.1
-    out.body[2][10, 17] = 0.2
-    out.body[1][8, 17] = 0.25
-    out.body[2][8, 17] = 0.4
-    out.body[1][12, 17] = 0.2
-    out.body[2][12, 17] = 0.3
-    out.body[1][13, 17] = 0.05
-    out.body[2][13, 17] = 0.4
-    out.body[3][13, 17] = 0.6
-    out.body[4][13, 17] = 0.7
-    out.body[1][13, 19] = 0.3
-    out.body[2][13, 19] = 0.5
-    out.body[3][14, 20] = 0.2
-    out.body[4][14, 20] = 0.4
-    out.body[1][14, 20] = 0.0
-    out.body[2][14, 20] = 0.0
-    out.terrain[11, 17] = 0.6
-    _move_intersecting_body!(out)
-    # Checking terrain
-    @test (out.terrain[11, 17] ≈ -0.5) && (out.terrain[10, 17] ≈ 0.1)
-    @test (out.terrain[8, 17] ≈ 0.25) && (out.terrain[12, 17] ≈ 0.2)
-    @test (out.terrain[13, 17] ≈ 0.05) && (out.terrain[13, 19] ≈ 0.3)
-    @test (out.terrain[14, 20] ≈ 0.2)
-    out.terrain[11, 17] = 0.0
-    out.terrain[10, 17] = 0.0
-    out.terrain[8, 17] = 0.0
-    out.terrain[12, 17] = 0.0
-    out.terrain[13, 17] = 0.0
-    out.terrain[13, 19] = 0.0
-    out.terrain[14, 20] = 0.0
-    @test all(out.terrain[:, :] .== 0.0)
-    # Resetting body
-    out.body[1][8:14, 14:20] .= 0.0
-    out.body[2][8:14, 14:20] .= 0.0
-    out.body[3][8:14, 14:20] .= 0.0
-    out.body[4][8:14, 14:20] .= 0.0
-
-    # Testing when there is nothing to move
-    out.body[1][8:14, 14:20] .= 0.0
-    out.body[2][8:14, 14:20] .= 0.2
-    _move_intersecting_body!(out)
-    # Checking terrain
-    @test all(out.terrain[:, :] .== 0.0)
-    # Resetting body
-    out.body[1][8:14, 14:20] .= 0.0
-    out.body[2][8:14, 14:20] .= 0.0
-
-    # Testing randomness of movement
-    set_RNG_seed!(1234)
-    out.body[1][11, 17] = -0.4
-    out.body[2][11, 17] = 0.6
-    out.terrain[11, 17] = 0.5
-    _move_intersecting_body!(out)
-    # Checking terrain
-    @test (out.terrain[11, 17] ≈ -0.4) && (out.terrain[12, 16] ≈ 0.9)
-    out.terrain[12, 16] = 0.0
-    out.terrain[11, 17] = 0.0
-    @test all(out.terrain[:, :] .== 0.0)
-    # Second call
-    out.terrain[11, 17] = 0.5
-    _move_intersecting_body!(out)
-    # Checking terrain
-    @test (out.terrain[11, 17] ≈ -0.4) && (out.terrain[10, 17] ≈ 0.9)
-    out.terrain[10, 17] = 0.0
-    out.terrain[11, 17] = 0.0
-    @test all(out.terrain[:, :] .== 0.0)
-    # Resetting body
-    out.body[1][11, 17] = 0.0
-    out.body[2][11, 17] = 0.0
-
-    # Removing zeros from Sparse matrices
-    dropzeros!(out.body[1])
-    dropzeros!(out.body[2])
-    dropzeros!(out.body[3])
-    dropzeros!(out.body[4])
-    dropzeros!(out.body_soil[1])
-    dropzeros!(out.body_soil[2])
-    dropzeros!(out.body_soil[3])
-    dropzeros!(out.body_soil[4])
-
-    # Checking that nothing has been unexpectedly modified
-    @test all(out.terrain[:, :] .== 0.0)
-    @test isempty(nonzeros(out.body[1]))
-    @test isempty(nonzeros(out.body[2]))
-    @test isempty(nonzeros(out.body[3]))
-    @test isempty(nonzeros(out.body[4]))
-    @test isempty(nonzeros(out.body_soil[1]))
-    @test isempty(nonzeros(out.body_soil[2]))
-    @test isempty(nonzeros(out.body_soil[3]))
-    @test isempty(nonzeros(out.body_soil[4]))
-end
-
 @testset "_move_intersecting_body_soil!" begin
     # Testing when soil is avalanching on the terrain (1)
     # First bucket layer at bottom
@@ -2434,6 +1945,495 @@ end
     out.body[3][13, 18] = 0.0
     out.body[4][13, 18] = 0.0
     empty!(out.body_soil_pos)
+
+    # Removing zeros from Sparse matrices
+    dropzeros!(out.body[1])
+    dropzeros!(out.body[2])
+    dropzeros!(out.body[3])
+    dropzeros!(out.body[4])
+    dropzeros!(out.body_soil[1])
+    dropzeros!(out.body_soil[2])
+    dropzeros!(out.body_soil[3])
+    dropzeros!(out.body_soil[4])
+
+    # Checking that nothing has been unexpectedly modified
+    @test all(out.terrain[:, :] .== 0.0)
+    @test isempty(nonzeros(out.body[1]))
+    @test isempty(nonzeros(out.body[2]))
+    @test isempty(nonzeros(out.body[3]))
+    @test isempty(nonzeros(out.body[4]))
+    @test isempty(nonzeros(out.body_soil[1]))
+    @test isempty(nonzeros(out.body_soil[2]))
+    @test isempty(nonzeros(out.body_soil[3]))
+    @test isempty(nonzeros(out.body_soil[4]))
+end
+
+@testset "_locate_intersecting_cells" begin
+    # Setting dummy values in body and terrain
+    out.terrain[10, 11:16] .= 0.1
+    out.terrain[11, 11] = -0.1
+    out.body[1][5, 10] = 0.0
+    out.body[2][5, 10] = 0.1
+    out.body[3][6, 10] = 0.0
+    out.body[4][6, 10] = 0.1
+    out.body[1][7, 10] = 0.0
+    out.body[2][7, 10] = 0.1
+    out.body[3][7, 10] = 0.2
+    out.body[4][7, 10] = 0.3
+    out.body[1][11, 11] = -0.1
+    out.body[2][11, 11] = 0.0
+    out.body[1][10, 11] = 0.0
+    out.body[2][10, 11] = 0.1
+    out.body[3][10, 12] = -0.1
+    out.body[4][10, 12] = 0.0
+    out.body[1][10, 13] = -0.2
+    out.body[2][10, 13] = 0.0
+    out.body[3][10, 13] = 0.0
+    out.body[4][10, 13] = 0.3
+    out.body[1][10, 14] = 0.2
+    out.body[2][10, 14] = 0.3
+    out.body[3][10, 14] = -0.1
+    out.body[4][10, 14] = 0.0
+    out.body[1][10, 15] = -0.3
+    out.body[2][10, 15] = -0.2
+    out.body[3][10, 15] = 0.5
+    out.body[4][10, 15] = 0.6
+    out.body[1][10, 16] = -0.3
+    out.body[2][10, 16] = -0.2
+    out.body[3][10, 16] = -0.6
+    out.body[4][10, 16] = -0.4
+
+    # Testing that intersecting cells are properly located
+    intersecting_cells = _locate_intersecting_cells(out)
+    @test ([1, 10, 11] in intersecting_cells) && ([3, 10, 12] in intersecting_cells)
+    @test ([1, 10, 13] in intersecting_cells) && ([3, 10, 13] in intersecting_cells)
+    @test ([3, 10, 14] in intersecting_cells) && ([1, 10, 15] in intersecting_cells)
+    @test ([1, 10, 13] in intersecting_cells) && ([3, 10, 16] in intersecting_cells)
+    @test (length(intersecting_cells) == 8)
+    # Resetting body and terrain
+    out.body[1][5, 10] = 0.0
+    out.body[2][5, 10] = 0.0
+    out.body[3][6, 10] = 0.0
+    out.body[4][6, 10] = 0.0
+    out.body[1][7, 10] = 0.0
+    out.body[2][7, 10] = 0.0
+    out.body[3][7, 10] = 0.0
+    out.body[4][7, 10] = 0.0
+    out.body[1][10, 11:16] .= 0.0
+    out.body[2][10, 11:16] .= 0.0
+    out.body[3][10, 11:16] .= 0.0
+    out.body[4][10, 11:16] .= 0.0
+    out.body[1][11, 11] = 0.0
+    out.body[2][11, 11] = 0.0
+    out.terrain[10, 11:16] .= 0.0
+    out.terrain[11, 11] = 0.0
+
+    # Removing zeros from Sparse matrices
+    dropzeros!(out.body[1])
+    dropzeros!(out.body[2])
+    dropzeros!(out.body[3])
+    dropzeros!(out.body[4])
+    dropzeros!(out.body_soil[1])
+    dropzeros!(out.body_soil[2])
+    dropzeros!(out.body_soil[3])
+    dropzeros!(out.body_soil[4])
+
+    # Checking that nothing has been unexpectedly modified
+    @test all(out.terrain[:, :] .== 0.0)
+    @test isempty(nonzeros(out.body[1]))
+    @test isempty(nonzeros(out.body[2]))
+    @test isempty(nonzeros(out.body[3]))
+    @test isempty(nonzeros(out.body[4]))
+    @test isempty(nonzeros(out.body_soil[1]))
+    @test isempty(nonzeros(out.body_soil[2]))
+    @test isempty(nonzeros(out.body_soil[3]))
+    @test isempty(nonzeros(out.body_soil[4]))
+end
+
+@testset "_move_intersecting_body!" begin
+    # Testing for a single intersecting cells in the -X direction
+    out.body[1][11:12, 16:18] .= 0.0
+    out.body[2][11:12, 16:18] .= 0.5
+    out.body[1][10, 16] = 0.0
+    out.body[2][10, 16] = 0.5
+    out.body[1][10, 18] = 0.0
+    out.body[2][10, 18] = 0.5
+    out.terrain[11, 17] = 0.1
+    _move_intersecting_body!(out)
+    # Checking terrain
+    @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[10, 17] ≈ 0.1)
+    out.terrain[10, 17] = 0.0
+    @test all(out.terrain[:, :] .== 0.0)
+    # Resetting body
+    out.body[1][10:12, 16:18] .= 0.0
+    out.body[2][10:12, 16:18] .= 0.0
+
+    # Testing for a single intersecting cells in the +X direction
+    out.body[1][10:11, 16:18] .= 0.0
+    out.body[2][10:11, 16:18] .= 0.5
+    out.body[1][12, 16] = 0.0
+    out.body[2][12, 16] = 0.5
+    out.body[1][12, 18] = 0.0
+    out.body[2][12, 18] = 0.5
+    out.terrain[11, 17] = 0.2
+    _move_intersecting_body!(out)
+    # Checking terrain
+    @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[12, 17] ≈ 0.2)
+    out.terrain[12, 17] = 0.0
+    @test all(out.terrain[:, :] .== 0.0)
+    # Resetting body
+    out.body[1][10:12, 16:18] .= 0.0
+    out.body[2][10:12, 16:18] .= 0.0
+
+    # Testing for a single intersecting cells in the -Y direction
+    out.body[1][10:12, 17:18] .= 0.0
+    out.body[2][10:12, 17:18] .= 0.5
+    out.body[1][10, 16] = 0.0
+    out.body[2][10, 16] = 0.5
+    out.body[1][12, 16] = 0.0
+    out.body[2][12, 16] = 0.5
+    out.terrain[11, 17] = 0.05
+    _move_intersecting_body!(out)
+    # Checking terrain
+    @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[11, 16] ≈ 0.05)
+    out.terrain[11, 16] = 0.0
+    @test all(out.terrain[:, :] .== 0.0)
+    # Resetting body
+    out.body[1][10:12, 16:18] .= 0.0
+    out.body[2][10:12, 16:18] .= 0.0
+
+    # Testing for a single intersecting cells in the +Y direction
+    out.body[1][10:12, 16:17] .= 0.0
+    out.body[2][10:12, 16:17] .= 0.5
+    out.body[1][10, 18] = 0.0
+    out.body[2][10, 18] = 0.5
+    out.body[1][12, 18] = 0.0
+    out.body[2][12, 18] = 0.5
+    out.terrain[11, 17] = 0.25
+    _move_intersecting_body!(out)
+    # Checking terrain
+    @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[11, 18] ≈ 0.25)
+    out.terrain[11, 18] = 0.0
+    @test all(out.terrain[:, :] .== 0.0)
+    # Resetting body
+    out.body[1][10:12, 16:18] .= 0.0
+    out.body[2][10:12, 16:18] .= 0.0
+
+    # Testing for a single intersecting cells in the -X-Y direction
+    out.body[1][10:12, 17:18] .= 0.0
+    out.body[2][10:12, 17:18] .= 0.5
+    out.body[1][11, 16] = 0.0
+    out.body[2][11, 16] = 0.5
+    out.body[1][12, 16] = 0.0
+    out.body[2][12, 16] = 0.5
+    out.terrain[11, 17] = 0.4
+    _move_intersecting_body!(out)
+    # Checking terrain
+    @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[10, 16] ≈ 0.4)
+    out.terrain[10, 16] = 0.0
+    @test all(out.terrain[:, :] .== 0.0)
+    # Resetting body
+    out.body[1][10:12, 16:18] .= 0.0
+    out.body[2][10:12, 16:18] .= 0.0
+
+    # Testing for a single intersecting cells in the +X-Y direction
+    out.body[1][10:12, 17:18] .= 0.0
+    out.body[2][10:12, 17:18] .= 0.5
+    out.body[1][10, 16] = 0.0
+    out.body[2][10, 16] = 0.5
+    out.body[1][11, 16] = 0.0
+    out.body[2][11, 16] = 0.5
+    out.terrain[11, 17] = 0.1
+    _move_intersecting_body!(out)
+    # Checking terrain
+    @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[12, 16] ≈ 0.1)
+    out.terrain[12, 16] = 0.0
+    @test all(out.terrain[:, :] .== 0.0)
+    # Resetting body
+    out.body[1][10:12, 16:18] .= 0.0
+    out.body[2][10:12, 16:18] .= 0.0
+
+    # Testing for a single intersecting cells in the -X+Y direction
+    out.body[1][10:12, 16:17] .= 0.0
+    out.body[2][10:12, 16:17] .= 0.5
+    out.body[1][11, 18] = 0.0
+    out.body[2][11, 18] = 0.5
+    out.body[1][12, 18] = 0.0
+    out.body[2][12, 18] = 0.5
+    out.terrain[11, 17] = 0.5
+    _move_intersecting_body!(out)
+    # Checking terrain
+    @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[10, 18] ≈ 0.5)
+    out.terrain[10, 18] = 0.0
+    @test all(out.terrain[:, :] .== 0.0)
+    # Resetting body
+    out.body[1][10:12, 16:18] .= 0.0
+    out.body[2][10:12, 16:18] .= 0.0
+
+    # Testing for a single intersecting cells in the +X+Y direction
+    out.body[1][10:12, 16:17] .= 0.0
+    out.body[2][10:12, 16:17] .= 0.5
+    out.body[1][10, 18] = 0.0
+    out.body[2][10, 18] = 0.5
+    out.body[1][11, 18] = 0.0
+    out.body[2][11, 18] = 0.5
+    out.terrain[11, 17] = 0.8
+    _move_intersecting_body!(out)
+    # Checking terrain
+    @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[12, 18] ≈ 0.8)
+    out.terrain[12, 18] = 0.0
+    @test all(out.terrain[:, :] .== 0.0)
+    # Resetting body
+    out.body[1][10:12, 16:18] .= 0.0
+    out.body[2][10:12, 16:18] .= 0.0
+
+    # Testing for a single intersecting cells in the second bucket layer
+    out.body[3][10:12, 16:17] .= 0.0
+    out.body[4][10:12, 16:17] .= 0.5
+    out.body[3][11, 18] = 0.0
+    out.body[4][11, 18] = 0.5
+    out.body[3][12, 18] = 0.0
+    out.body[4][12, 18] = 0.5
+    out.terrain[11, 17] = 0.5
+    _move_intersecting_body!(out)
+    # Checking terrain
+    @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[10, 18] ≈ 0.5)
+    out.terrain[10, 18] = 0.0
+    @test all(out.terrain[:, :] .== 0.0)
+    # Resetting body
+    out.body[3][10:12, 16:18] .= 0.0
+    out.body[4][10:12, 16:18] .= 0.0
+
+    # Testing for a single intersecting cells with various bucket layer
+    out.body[3][10, 16:17] .= 0.0
+    out.body[4][10, 16:17] .= 0.5
+    out.body[1][11, 16:17] .= 0.0
+    out.body[2][11, 16:17] .= 0.5
+    out.body[1][12, 16:17] .= 0.0
+    out.body[2][12, 16:17] .= 0.5
+    out.body[3][12, 16:17] .= 0.6
+    out.body[4][12, 16:17] .= 0.8
+    out.body[1][11, 18] = 0.0
+    out.body[2][11, 18] = 0.5
+    out.body[3][12, 18] = 0.0
+    out.body[4][12, 18] = 0.5
+    out.terrain[11, 17] = 0.5
+    _move_intersecting_body!(out)
+    # Checking terrain
+    @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[10, 18] ≈ 0.5)
+    out.terrain[10, 18] = 0.0
+    @test all(out.terrain[:, :] .== 0.0)
+    # Resetting body
+    out.body[3][10:12, 16:18] .= 0.0
+    out.body[4][10:12, 16:18] .= 0.0
+
+    # Testing for a single intersecting cells with all bucket under terrain
+    out.body[1][10:12, 16:17] .= 0.0
+    out.body[2][10:12, 16:17] .= 0.2
+    out.body[1][10, 18] = 0.0
+    out.body[2][10, 18] = 0.5
+    out.body[1][11, 18] = 0.0
+    out.body[2][11, 18] = 0.5
+    out.body[1][11, 17] = 0.5
+    out.body[2][11, 17] = 0.6
+    out.body[3][11, 17] = -0.2
+    out.body[4][11, 17] = 0.3
+    out.terrain[11, 17] = 0.8
+    _move_intersecting_body!(out)
+    # Checking terrain
+    @test (out.terrain[11, 17] ≈ -0.2) && (out.terrain[12, 18] ≈ 1.0)
+    out.terrain[12, 18] = 0.0
+    out.terrain[11, 17] = 0.0
+    @test all(out.terrain[:, :] .== 0.0)
+    # Resetting body
+    out.body[1][10:12, 16:18] .= 0.0
+    out.body[2][10:12, 16:18] .= 0.0
+    out.body[3][11, 17] = 0.0
+    out.body[4][11, 17] = 0.0
+
+    # Testing for a single intersecting cells under a large bucket
+    out.body[1][8:14, 14:20] .= 0.0
+    out.body[2][8:14, 14:20] .= 0.2
+    out.body[1][11, 17] = -0.4
+    out.body[2][11, 17] = 0.6
+    out.body[1][8, 17] = 0.0
+    out.body[2][8, 17] = 0.0
+    out.terrain[11, 17] = 0.5
+    _move_intersecting_body!(out)
+    # Checking terrain
+    @test (out.terrain[11, 17] ≈ -0.4) && (out.terrain[8, 17] ≈ 0.9)
+    out.terrain[8, 17] = 0.0
+    out.terrain[11, 17] = 0.0
+    @test all(out.terrain[:, :] .== 0.0)
+    # Resetting body
+    out.body[1][8:14, 14:20] .= 0.0
+    out.body[2][8:14, 14:20] .= 0.0
+
+    # Testing when soil is moved by small amount (1)
+    # Soil is fitting under the bucket
+    set_RNG_seed!(1234)
+    out.body[1][8:14, 14:20] .= 0.0
+    out.body[2][8:14, 14:20] .= 0.2
+    out.body[1][11, 17] = -0.5
+    out.body[2][11, 17] = 0.6
+    out.body[1][10, 17] = 0.1
+    out.body[2][10, 17] = 0.2
+    out.body[1][8, 17] = 0.25
+    out.body[2][8, 17] = 0.4
+    out.body[1][12, 17] = 0.2
+    out.body[2][12, 17] = 0.3
+    out.body[1][13, 17] = 0.05
+    out.body[2][13, 17] = 0.4
+    out.body[3][13, 17] = 0.6
+    out.body[4][13, 17] = 0.7
+    out.body[1][13, 19] = 0.3
+    out.body[2][13, 19] = 0.5
+    out.body[3][14, 20] = 0.2
+    out.body[4][14, 20] = 0.4
+    out.body[1][14, 20] = 0.0
+    out.body[2][14, 20] = 0.0
+    out.terrain[11, 17] = 0.5
+    _move_intersecting_body!(out)
+    # Checking terrain
+    @test (out.terrain[11, 17] ≈ -0.5) && (out.terrain[10, 17] ≈ 0.1)
+    @test (out.terrain[8, 17] ≈ 0.15) && (out.terrain[12, 17] ≈ 0.2)
+    @test (out.terrain[13, 17] ≈ 0.05) && (out.terrain[13, 19] ≈ 0.3)
+    @test (out.terrain[14, 20] ≈ 0.2)
+    out.terrain[11, 17] = 0.0
+    out.terrain[10, 17] = 0.0
+    out.terrain[8, 17] = 0.0
+    out.terrain[12, 17] = 0.0
+    out.terrain[13, 17] = 0.0
+    out.terrain[13, 19] = 0.0
+    out.terrain[14, 20] = 0.0
+    @test all(out.terrain[:, :] .== 0.0)
+    # Resetting body
+    out.body[1][8:14, 14:20] .= 0.0
+    out.body[2][8:14, 14:20] .= 0.0
+    out.body[3][8:14, 14:20] .= 0.0
+    out.body[4][8:14, 14:20] .= 0.0
+
+    # Testing when soil is moved by small amount (2)
+    # Soil is going out of the bucket
+    set_RNG_seed!(1234)
+    out.body[1][8:14, 14:20] .= 0.0
+    out.body[2][8:14, 14:20] .= 0.2
+    out.body[1][11, 17] = -0.5
+    out.body[2][11, 17] = 0.6
+    out.body[1][10, 17] = 0.1
+    out.body[2][10, 17] = 0.2
+    out.body[1][8, 17] = 0.25
+    out.body[2][8, 17] = 0.4
+    out.body[1][12, 17] = 0.2
+    out.body[2][12, 17] = 0.3
+    out.body[1][13, 17] = 0.05
+    out.body[2][13, 17] = 0.4
+    out.body[3][13, 17] = 0.6
+    out.body[4][13, 17] = 0.7
+    out.body[1][13, 19] = 0.3
+    out.body[2][13, 19] = 0.5
+    out.body[3][14, 20] = 0.2
+    out.body[4][14, 20] = 0.4
+    out.body[1][14, 20] = 0.0
+    out.body[2][14, 20] = 0.0
+    out.terrain[11, 17] = 0.8
+    _move_intersecting_body!(out)
+    # Checking terrain
+    @test (out.terrain[11, 17] ≈ -0.5) && (out.terrain[10, 17] ≈ 0.1)
+    @test (out.terrain[8, 17] ≈ 0.25) && (out.terrain[12, 17] ≈ 0.2)
+    @test (out.terrain[13, 17] ≈ 0.05) && (out.terrain[13, 19] ≈ 0.3)
+    @test (out.terrain[14, 20] ≈ 0.2) && (out.terrain[15, 13] ≈ 0.2)
+    out.terrain[11, 17] = 0.0
+    out.terrain[10, 17] = 0.0
+    out.terrain[8, 17] = 0.0
+    out.terrain[12, 17] = 0.0
+    out.terrain[13, 17] = 0.0
+    out.terrain[13, 19] = 0.0
+    out.terrain[14, 20] = 0.0
+    out.terrain[15, 13] = 0.0
+    @test all(out.terrain[:, :] .== 0.0)
+    # Resetting body
+    out.body[1][8:14, 14:20] .= 0.0
+    out.body[2][8:14, 14:20] .= 0.0
+    out.body[3][8:14, 14:20] .= 0.0
+    out.body[4][8:14, 14:20] .= 0.0
+
+    # Testing when soil is moved by small amount (3)
+    # Soil is just fitting under the bucket
+    set_RNG_seed!(1234)
+    out.body[1][8:14, 14:20] .= 0.0
+    out.body[2][8:14, 14:20] .= 0.2
+    out.body[1][11, 17] = -0.5
+    out.body[2][11, 17] = 0.6
+    out.body[1][10, 17] = 0.1
+    out.body[2][10, 17] = 0.2
+    out.body[1][8, 17] = 0.25
+    out.body[2][8, 17] = 0.4
+    out.body[1][12, 17] = 0.2
+    out.body[2][12, 17] = 0.3
+    out.body[1][13, 17] = 0.05
+    out.body[2][13, 17] = 0.4
+    out.body[3][13, 17] = 0.6
+    out.body[4][13, 17] = 0.7
+    out.body[1][13, 19] = 0.3
+    out.body[2][13, 19] = 0.5
+    out.body[3][14, 20] = 0.2
+    out.body[4][14, 20] = 0.4
+    out.body[1][14, 20] = 0.0
+    out.body[2][14, 20] = 0.0
+    out.terrain[11, 17] = 0.6
+    _move_intersecting_body!(out)
+    # Checking terrain
+    @test (out.terrain[11, 17] ≈ -0.5) && (out.terrain[10, 17] ≈ 0.1)
+    @test (out.terrain[8, 17] ≈ 0.25) && (out.terrain[12, 17] ≈ 0.2)
+    @test (out.terrain[13, 17] ≈ 0.05) && (out.terrain[13, 19] ≈ 0.3)
+    @test (out.terrain[14, 20] ≈ 0.2)
+    out.terrain[11, 17] = 0.0
+    out.terrain[10, 17] = 0.0
+    out.terrain[8, 17] = 0.0
+    out.terrain[12, 17] = 0.0
+    out.terrain[13, 17] = 0.0
+    out.terrain[13, 19] = 0.0
+    out.terrain[14, 20] = 0.0
+    @test all(out.terrain[:, :] .== 0.0)
+    # Resetting body
+    out.body[1][8:14, 14:20] .= 0.0
+    out.body[2][8:14, 14:20] .= 0.0
+    out.body[3][8:14, 14:20] .= 0.0
+    out.body[4][8:14, 14:20] .= 0.0
+
+    # Testing when there is nothing to move
+    out.body[1][8:14, 14:20] .= 0.0
+    out.body[2][8:14, 14:20] .= 0.2
+    _move_intersecting_body!(out)
+    # Checking terrain
+    @test all(out.terrain[:, :] .== 0.0)
+    # Resetting body
+    out.body[1][8:14, 14:20] .= 0.0
+    out.body[2][8:14, 14:20] .= 0.0
+
+    # Testing randomness of movement
+    set_RNG_seed!(1234)
+    out.body[1][11, 17] = -0.4
+    out.body[2][11, 17] = 0.6
+    out.terrain[11, 17] = 0.5
+    _move_intersecting_body!(out)
+    # Checking terrain
+    @test (out.terrain[11, 17] ≈ -0.4) && (out.terrain[12, 16] ≈ 0.9)
+    out.terrain[12, 16] = 0.0
+    out.terrain[11, 17] = 0.0
+    @test all(out.terrain[:, :] .== 0.0)
+    # Second call
+    out.terrain[11, 17] = 0.5
+    _move_intersecting_body!(out)
+    # Checking terrain
+    @test (out.terrain[11, 17] ≈ -0.4) && (out.terrain[10, 17] ≈ 0.9)
+    out.terrain[10, 17] = 0.0
+    out.terrain[11, 17] = 0.0
+    @test all(out.terrain[:, :] .== 0.0)
+    # Resetting body
+    out.body[1][11, 17] = 0.0
+    out.body[2][11, 17] = 0.0
 
     # Removing zeros from Sparse matrices
     dropzeros!(out.body[1])

--- a/test/unit_test/test_intersecting_cells.jl
+++ b/test/unit_test/test_intersecting_cells.jl
@@ -86,7 +86,7 @@ end
     out.body[1][10, 18] = 0.0
     out.body[2][10, 18] = 0.5
     out.terrain[11, 17] = 0.1
-    _move_intersecting_body!(out, grid)
+    _move_intersecting_body!(out)
     # Checking terrain
     @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[10, 17] ≈ 0.1)
     out.terrain[10, 17] = 0.0
@@ -103,7 +103,7 @@ end
     out.body[1][12, 18] = 0.0
     out.body[2][12, 18] = 0.5
     out.terrain[11, 17] = 0.2
-    _move_intersecting_body!(out, grid)
+    _move_intersecting_body!(out)
     # Checking terrain
     @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[12, 17] ≈ 0.2)
     out.terrain[12, 17] = 0.0
@@ -120,7 +120,7 @@ end
     out.body[1][12, 16] = 0.0
     out.body[2][12, 16] = 0.5
     out.terrain[11, 17] = 0.05
-    _move_intersecting_body!(out, grid)
+    _move_intersecting_body!(out)
     # Checking terrain
     @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[11, 16] ≈ 0.05)
     out.terrain[11, 16] = 0.0
@@ -137,7 +137,7 @@ end
     out.body[1][12, 18] = 0.0
     out.body[2][12, 18] = 0.5
     out.terrain[11, 17] = 0.25
-    _move_intersecting_body!(out, grid)
+    _move_intersecting_body!(out)
     # Checking terrain
     @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[11, 18] ≈ 0.25)
     out.terrain[11, 18] = 0.0
@@ -154,7 +154,7 @@ end
     out.body[1][12, 16] = 0.0
     out.body[2][12, 16] = 0.5
     out.terrain[11, 17] = 0.4
-    _move_intersecting_body!(out, grid)
+    _move_intersecting_body!(out)
     # Checking terrain
     @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[10, 16] ≈ 0.4)
     out.terrain[10, 16] = 0.0
@@ -171,7 +171,7 @@ end
     out.body[1][11, 16] = 0.0
     out.body[2][11, 16] = 0.5
     out.terrain[11, 17] = 0.1
-    _move_intersecting_body!(out, grid)
+    _move_intersecting_body!(out)
     # Checking terrain
     @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[12, 16] ≈ 0.1)
     out.terrain[12, 16] = 0.0
@@ -188,7 +188,7 @@ end
     out.body[1][12, 18] = 0.0
     out.body[2][12, 18] = 0.5
     out.terrain[11, 17] = 0.5
-    _move_intersecting_body!(out, grid)
+    _move_intersecting_body!(out)
     # Checking terrain
     @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[10, 18] ≈ 0.5)
     out.terrain[10, 18] = 0.0
@@ -205,7 +205,7 @@ end
     out.body[1][11, 18] = 0.0
     out.body[2][11, 18] = 0.5
     out.terrain[11, 17] = 0.8
-    _move_intersecting_body!(out, grid)
+    _move_intersecting_body!(out)
     # Checking terrain
     @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[12, 18] ≈ 0.8)
     out.terrain[12, 18] = 0.0
@@ -222,7 +222,7 @@ end
     out.body[3][12, 18] = 0.0
     out.body[4][12, 18] = 0.5
     out.terrain[11, 17] = 0.5
-    _move_intersecting_body!(out, grid)
+    _move_intersecting_body!(out)
     # Checking terrain
     @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[10, 18] ≈ 0.5)
     out.terrain[10, 18] = 0.0
@@ -245,7 +245,7 @@ end
     out.body[3][12, 18] = 0.0
     out.body[4][12, 18] = 0.5
     out.terrain[11, 17] = 0.5
-    _move_intersecting_body!(out, grid)
+    _move_intersecting_body!(out)
     # Checking terrain
     @test (out.terrain[11, 17] ≈ 0.0) && (out.terrain[10, 18] ≈ 0.5)
     out.terrain[10, 18] = 0.0
@@ -266,7 +266,7 @@ end
     out.body[3][11, 17] = -0.2
     out.body[4][11, 17] = 0.3
     out.terrain[11, 17] = 0.8
-    _move_intersecting_body!(out, grid)
+    _move_intersecting_body!(out)
     # Checking terrain
     @test (out.terrain[11, 17] ≈ -0.2) && (out.terrain[12, 18] ≈ 1.0)
     out.terrain[12, 18] = 0.0
@@ -286,7 +286,7 @@ end
     out.body[1][8, 17] = 0.0
     out.body[2][8, 17] = 0.0
     out.terrain[11, 17] = 0.5
-    _move_intersecting_body!(out, grid)
+    _move_intersecting_body!(out)
     # Checking terrain
     @test (out.terrain[11, 17] ≈ -0.4) && (out.terrain[8, 17] ≈ 0.9)
     out.terrain[8, 17] = 0.0
@@ -320,7 +320,7 @@ end
     out.body[1][14, 20] = 0.0
     out.body[2][14, 20] = 0.0
     out.terrain[11, 17] = 0.5
-    _move_intersecting_body!(out, grid)
+    _move_intersecting_body!(out)
     # Checking terrain
     @test (out.terrain[11, 17] ≈ -0.5) && (out.terrain[10, 17] ≈ 0.1)
     @test (out.terrain[8, 17] ≈ 0.15) && (out.terrain[12, 17] ≈ 0.2)
@@ -364,7 +364,7 @@ end
     out.body[1][14, 20] = 0.0
     out.body[2][14, 20] = 0.0
     out.terrain[11, 17] = 0.8
-    _move_intersecting_body!(out, grid)
+    _move_intersecting_body!(out)
     # Checking terrain
     @test (out.terrain[11, 17] ≈ -0.5) && (out.terrain[10, 17] ≈ 0.1)
     @test (out.terrain[8, 17] ≈ 0.25) && (out.terrain[12, 17] ≈ 0.2)
@@ -409,7 +409,7 @@ end
     out.body[1][14, 20] = 0.0
     out.body[2][14, 20] = 0.0
     out.terrain[11, 17] = 0.6
-    _move_intersecting_body!(out, grid)
+    _move_intersecting_body!(out)
     # Checking terrain
     @test (out.terrain[11, 17] ≈ -0.5) && (out.terrain[10, 17] ≈ 0.1)
     @test (out.terrain[8, 17] ≈ 0.25) && (out.terrain[12, 17] ≈ 0.2)
@@ -432,7 +432,7 @@ end
     # Testing when there is nothing to move
     out.body[1][8:14, 14:20] .= 0.0
     out.body[2][8:14, 14:20] .= 0.2
-    _move_intersecting_body!(out, grid)
+    _move_intersecting_body!(out)
     # Checking terrain
     @test all(out.terrain[:, :] .== 0.0)
     # Resetting body
@@ -444,7 +444,7 @@ end
     out.body[1][11, 17] = -0.4
     out.body[2][11, 17] = 0.6
     out.terrain[11, 17] = 0.5
-    _move_intersecting_body!(out, grid)
+    _move_intersecting_body!(out)
     # Checking terrain
     @test (out.terrain[11, 17] ≈ -0.4) && (out.terrain[12, 16] ≈ 0.9)
     out.terrain[12, 16] = 0.0
@@ -452,7 +452,7 @@ end
     @test all(out.terrain[:, :] .== 0.0)
     # Second call
     out.terrain[11, 17] = 0.5
-    _move_intersecting_body!(out, grid)
+    _move_intersecting_body!(out)
     # Checking terrain
     @test (out.terrain[11, 17] ≈ -0.4) && (out.terrain[10, 17] ≈ 0.9)
     out.terrain[10, 17] = 0.0
@@ -478,7 +478,7 @@ end
     out.body_soil[4][10, 15] = 0.7
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.3) && (out.body_soil[2][10, 15] ≈ 0.5)
     @test (out.body_soil[3][10, 15] == 0.6) && (out.body_soil[4][10, 15] == 0.7)
     @test (out.terrain[11, 14] ≈ 0.3)
@@ -508,7 +508,7 @@ end
     out.body_soil[4][10, 15] = 0.8
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.6) && (out.body_soil[2][10, 15] == 0.7)
     @test (out.body_soil[3][10, 15] == 0.3) && (out.body_soil[4][10, 15] ≈ 0.5)
     @test (out.terrain[11, 14] ≈ 0.3)
@@ -538,7 +538,7 @@ end
     out.body_soil[4][10, 15] = 0.1
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == -0.5) && (out.body_soil[2][10, 15] ≈ -0.3)
     @test (out.body_soil[3][10, 15] == 0.0) && (out.body_soil[4][10, 15] == 0.1)
     @test (out.terrain[11, 14] ≈ 0.3)
@@ -569,7 +569,7 @@ end
     out.body[2][11, 14] = 1.0
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.3) && (out.body_soil[2][10, 15] ≈ 0.5)
     @test (out.body_soil[3][10, 15] == 0.6) && (out.body_soil[4][10, 15] == 0.7)
     @test (out.terrain[11, 14] ≈ 0.3)
@@ -602,7 +602,7 @@ end
     out.body[2][11, 14] = 0.5
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.3) && (out.body_soil[2][10, 15] ≈ 0.5)
     @test (out.body_soil[3][10, 15] == 0.6) && (out.body_soil[4][10, 15] == 0.7)
     @test (out.terrain[11, 14] ≈ 0.3)
@@ -635,7 +635,7 @@ end
     out.body[2][11, 14] = 1.0
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.6) && (out.body_soil[2][10, 15] == 0.7)
     @test (out.body_soil[3][10, 15] == 0.3) && (out.body_soil[4][10, 15] ≈ 0.5)
     @test (out.terrain[11, 14] ≈ 0.3)
@@ -668,7 +668,7 @@ end
     out.body[4][11, 14] = 1.0
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.3) && (out.body_soil[2][10, 15] ≈ 0.5)
     @test (out.body_soil[3][10, 15] == 0.6) && (out.body_soil[4][10, 15] == 0.7)
     @test (out.terrain[11, 14] ≈ 0.3)
@@ -701,7 +701,7 @@ end
     out.body[4][11, 14] = 0.5
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.3) && (out.body_soil[2][10, 15] ≈ 0.5)
     @test (out.body_soil[3][10, 15] == 0.6) && (out.body_soil[4][10, 15] == 0.7)
     @test (out.terrain[11, 14] ≈ 0.3)
@@ -734,7 +734,7 @@ end
     out.body[4][11, 14] = 1.0
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.6) && (out.body_soil[2][10, 15] == 0.7)
     @test (out.body_soil[3][10, 15] == 0.3) && (out.body_soil[4][10, 15] ≈ 0.5)
     @test (out.terrain[11, 14] ≈ 0.3)
@@ -767,7 +767,7 @@ end
     out.body[2][11, 14] = 0.2
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.3) && (out.body_soil[2][10, 15] ≈ 0.5)
     @test (out.body_soil[3][10, 15] == 0.6) && (out.body_soil[4][10, 15] == 0.7)
     @test (out.body_soil[1][11, 14] ≈ 0.2) && (out.body_soil[2][11, 14] ≈ 0.5)
@@ -801,7 +801,7 @@ end
     out.body[2][11, 14] = 0.2
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.6) && (out.body_soil[2][10, 15] == 0.7)
     @test (out.body_soil[3][10, 15] == 0.3) && (out.body_soil[4][10, 15] ≈ 0.5)
     @test (out.body_soil[1][11, 14] ≈ 0.2) && (out.body_soil[2][11, 14] ≈ 0.5)
@@ -835,7 +835,7 @@ end
     out.body[4][11, 14] = 0.2
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.3) && (out.body_soil[2][10, 15] ≈ 0.5)
     @test (out.body_soil[3][10, 15] == 0.6) && (out.body_soil[4][10, 15] == 0.7)
     @test (out.body_soil[3][11, 14] ≈ 0.2) && (out.body_soil[4][11, 14] ≈ 0.5)
@@ -869,7 +869,7 @@ end
     out.body[4][11, 14] = 0.2
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.6) && (out.body_soil[2][10, 15] == 0.7)
     @test (out.body_soil[3][10, 15] == 0.3) && (out.body_soil[4][10, 15] ≈ 0.5)
     @test (out.body_soil[3][11, 14] ≈ 0.2) && (out.body_soil[4][11, 14] ≈ 0.5)
@@ -906,7 +906,7 @@ end
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
     push!(out.body_soil_pos, [1; 11; 14])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.3) && (out.body_soil[2][10, 15] ≈ 0.5)
     @test (out.body_soil[3][10, 15] == 0.6) && (out.body_soil[4][10, 15] == 0.7)
     @test (out.body_soil[1][11, 14] == 0.1) && (out.body_soil[2][11, 14] ≈ 0.5)
@@ -943,7 +943,7 @@ end
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
     push!(out.body_soil_pos, [1; 11; 14])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.6) && (out.body_soil[2][10, 15] == 0.7)
     @test (out.body_soil[3][10, 15] == 0.3) && (out.body_soil[4][10, 15] ≈ 0.5)
     @test (out.body_soil[1][11, 14] == 0.1) && (out.body_soil[2][11, 14] ≈ 0.5)
@@ -980,7 +980,7 @@ end
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
     push!(out.body_soil_pos, [3; 11; 14])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.3) && (out.body_soil[2][10, 15] ≈ 0.5)
     @test (out.body_soil[3][10, 15] == 0.6) && (out.body_soil[4][10, 15] == 0.7)
     @test (out.body_soil[3][11, 14] == 0.1) && (out.body_soil[4][11, 14] ≈ 0.5)
@@ -1017,7 +1017,7 @@ end
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
     push!(out.body_soil_pos, [3; 11; 14])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.6) && (out.body_soil[2][10, 15] == 0.7)
     @test (out.body_soil[3][10, 15] == 0.3) && (out.body_soil[4][10, 15] ≈ 0.5)
     @test (out.body_soil[3][11, 14] == 0.1) && (out.body_soil[4][11, 14] ≈ 0.5)
@@ -1054,7 +1054,7 @@ end
     out.body[4][11, 14] = 0.7
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.3) && (out.body_soil[2][10, 15] ≈ 0.5)
     @test (out.body_soil[3][10, 15] == 0.6) && (out.body_soil[4][10, 15] == 0.7)
     @test (out.body_soil[1][11, 14] ≈ 0.2) && (out.body_soil[2][11, 14] ≈ 0.5)
@@ -1093,7 +1093,7 @@ end
     out.body[4][11, 14] = 0.7
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.6) && (out.body_soil[2][10, 15] == 0.7)
     @test (out.body_soil[3][10, 15] == 0.3) && (out.body_soil[4][10, 15] ≈ 0.5)
     @test (out.body_soil[1][11, 14] ≈ 0.2) && (out.body_soil[2][11, 14] ≈ 0.5)
@@ -1132,7 +1132,7 @@ end
     out.body[4][11, 14] = 0.2
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.3) && (out.body_soil[2][10, 15] ≈ 0.5)
     @test (out.body_soil[3][10, 15] == 0.6) && (out.body_soil[4][10, 15] == 0.7)
     @test (out.body_soil[3][11, 14] ≈ 0.2) && (out.body_soil[4][11, 14] ≈ 0.5)
@@ -1171,7 +1171,7 @@ end
     out.body[4][11, 14] = 0.2
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.6) && (out.body_soil[2][10, 15] == 0.7)
     @test (out.body_soil[3][10, 15] == 0.3) && (out.body_soil[4][10, 15] ≈ 0.5)
     @test (out.body_soil[3][11, 14] ≈ 0.2) && (out.body_soil[4][11, 14] ≈ 0.5)
@@ -1213,7 +1213,7 @@ end
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
     push!(out.body_soil_pos, [1; 11; 14])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.3) && (out.body_soil[2][10, 15] ≈ 0.5)
     @test (out.body_soil[3][10, 15] == 0.6) && (out.body_soil[4][10, 15] == 0.7)
     @test (out.body_soil[1][11, 14] == 0.1) && (out.body_soil[2][11, 14] ≈ 0.5)
@@ -1255,7 +1255,7 @@ end
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
     push!(out.body_soil_pos, [1; 11; 14])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.6) && (out.body_soil[2][10, 15] == 0.7)
     @test (out.body_soil[3][10, 15] == 0.3) && (out.body_soil[4][10, 15] ≈ 0.5)
     @test (out.body_soil[1][11, 14] ≈ 0.1) && (out.body_soil[2][11, 14] ≈ 0.5)
@@ -1297,7 +1297,7 @@ end
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
     push!(out.body_soil_pos, [3; 11; 14])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.3) && (out.body_soil[2][10, 15] ≈ 0.5)
     @test (out.body_soil[3][10, 15] == 0.6) && (out.body_soil[4][10, 15] == 0.7)
     @test (out.body_soil[3][11, 14] ≈ 0.1) && (out.body_soil[4][11, 14] ≈ 0.5)
@@ -1339,7 +1339,7 @@ end
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
     push!(out.body_soil_pos, [3; 11; 14])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.6) && (out.body_soil[2][10, 15] == 0.7)
     @test (out.body_soil[3][10, 15] == 0.3) && (out.body_soil[4][10, 15] ≈ 0.5)
     @test (out.body_soil[3][11, 14] ≈ 0.1) && (out.body_soil[4][11, 14] ≈ 0.5)
@@ -1378,7 +1378,7 @@ end
     out.body[4][11, 14] = 0.7
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.3) && (out.body_soil[2][10, 15] ≈ 0.5)
     @test (out.body_soil[3][10, 15] == 0.6) && (out.body_soil[4][10, 15] == 0.7)
     @test (out.body_soil[1][11, 14] ≈ 0.2) && (out.body_soil[2][11, 14] ≈ 0.4)
@@ -1419,7 +1419,7 @@ end
     out.body[4][11, 14] = 0.7
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.6) && (out.body_soil[2][10, 15] == 0.7)
     @test (out.body_soil[3][10, 15] == 0.3) && (out.body_soil[4][10, 15] ≈ 0.5)
     @test (out.body_soil[1][11, 14] ≈ 0.2) && (out.body_soil[2][11, 14] ≈ 0.4)
@@ -1460,7 +1460,7 @@ end
     out.body[4][11, 14] = 0.2
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.3) && (out.body_soil[2][10, 15] ≈ 0.5)
     @test (out.body_soil[3][10, 15] == 0.6) && (out.body_soil[4][10, 15] == 0.7)
     @test (out.body_soil[3][11, 14] ≈ 0.2) && (out.body_soil[4][11, 14] ≈ 0.4)
@@ -1501,7 +1501,7 @@ end
     out.body[4][11, 14] = 0.2
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.6) && (out.body_soil[2][10, 15] == 0.7)
     @test (out.body_soil[3][10, 15] == 0.3) && (out.body_soil[4][10, 15] ≈ 0.5)
     @test (out.body_soil[3][11, 14] ≈ 0.2) && (out.body_soil[4][11, 14] ≈ 0.4)
@@ -1545,7 +1545,7 @@ end
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
     push!(out.body_soil_pos, [1; 11; 14])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.3) && (out.body_soil[2][10, 15] ≈ 0.5)
     @test (out.body_soil[3][10, 15] == 0.6) && (out.body_soil[4][10, 15] == 0.7)
     @test (out.body_soil[1][11, 14] == 0.1) && (out.body_soil[2][11, 14] ≈ 0.4)
@@ -1589,7 +1589,7 @@ end
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
     push!(out.body_soil_pos, [1; 11; 14])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.6) && (out.body_soil[2][10, 15] == 0.7)
     @test (out.body_soil[3][10, 15] == 0.3) && (out.body_soil[4][10, 15] ≈ 0.5)
     @test (out.body_soil[1][11, 14] ≈ 0.1) && (out.body_soil[2][11, 14] ≈ 0.4)
@@ -1633,7 +1633,7 @@ end
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
     push!(out.body_soil_pos, [3; 11; 14])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.3) && (out.body_soil[2][10, 15] ≈ 0.5)
     @test (out.body_soil[3][10, 15] == 0.6) && (out.body_soil[4][10, 15] == 0.7)
     @test (out.body_soil[3][11, 14] ≈ 0.1) && (out.body_soil[4][11, 14] ≈ 0.4)
@@ -1677,7 +1677,7 @@ end
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
     push!(out.body_soil_pos, [3; 11; 14])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.6) && (out.body_soil[2][10, 15] == 0.7)
     @test (out.body_soil[3][10, 15] == 0.3) && (out.body_soil[4][10, 15] ≈ 0.5)
     @test (out.body_soil[3][11, 14] ≈ 0.1) && (out.body_soil[4][11, 14] ≈ 0.4)
@@ -1717,7 +1717,7 @@ end
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
     push!(out.body_soil_pos, [3; 11; 14])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.6) && (out.body_soil[2][10, 15] == 0.9)
     @test (out.body_soil[3][10, 15] == 0.3) && (out.body_soil[4][10, 15] == 0.5)
     @test (out.body_soil[3][11, 14] == 0.1) && (out.body_soil[4][11, 14] == 0.9)
@@ -1749,7 +1749,7 @@ end
     out.body_soil[4][10, 15] = 0.7
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.3) && (out.body_soil[2][10, 15] ≈ 0.5)
     @test (out.body_soil[3][10, 15] == 0.6) && (out.body_soil[4][10, 15] == 0.7)
     @test (out.terrain[11, 14] ≈ 0.3)
@@ -1758,7 +1758,7 @@ end
     out.body_soil[1][10, 15] = 0.3
     out.body_soil[2][10, 15] = 0.8
     set_RNG_seed!(1236)
-    _move_intersecting_body_soil!(out, grid)
+    _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.3) && (out.body_soil[2][10, 15] ≈ 0.5)
     @test (out.body_soil[3][10, 15] == 0.6) && (out.body_soil[4][10, 15] == 0.7)
     @test (out.terrain[9, 16] ≈ 0.3)
@@ -1850,9 +1850,7 @@ end
     push!(out.body_soil_pos, [3; 10; 16])
     push!(out.body_soil_pos, [3; 11; 16])
     push!(out.body_soil_pos, [3; 12; 17])
-    @test_logs (:warn, warning_message) match_mode=:any _move_intersecting_body_soil!(
-            out, grid
-        )
+    @test_logs (:warn, warning_message) match_mode=:any _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.6) && (out.body_soil[2][10, 15] == 0.7)
     @test (out.body_soil[3][10, 15] == 0.3) && (out.body_soil[4][10, 15] ≈ 0.7)
     @test (out.body_soil[1][11, 15] == 0.2) && (out.body_soil[2][11, 15] == 0.7)

--- a/test/unit_test/test_intersecting_cells.jl
+++ b/test/unit_test/test_intersecting_cells.jl
@@ -464,7 +464,6 @@ end
 end
 
 @testset "_move_intersecting_body_soil!" begin
-"""
     # Testing when soil is avalanching on the terrain (1)
     # First bucket layer at bottom
     set_RNG_seed!(1234)
@@ -1774,7 +1773,7 @@ end
     out.body_soil[3][10, 15] = 0.0
     out.body_soil[4][10, 15] = 0.0
     empty!(out.body_soil_pos)
-"""
+
     # Testing that warning is properly sent when soil cannot be moved
     warning_message = "Not all soil intersecting with a bucket layer could be moved\n" *
         "The extra soil has been arbitrarily removed"
@@ -1790,17 +1789,17 @@ end
     out.body[1][9, 14] = 0.2
     out.body[2][9, 14] = 0.9
     out.body[1][10, 14] = 0.0
-    out.body[2][10, 14] = 0.1
-    out.body[3][10, 14] = 0.3
+    out.body[2][10, 14] = 0.5
+    out.body[3][10, 14] = 0.6
     out.body[4][10, 14] = 0.7
     out.body[1][11, 14] = 0.8
     out.body[2][11, 14] = 0.9
     out.body[3][11, 14] = 0.3
     out.body[4][11, 14] = 0.5
-    out.body[1][9, 15] = 0.2
-    out.body[2][9, 15] = 0.7
+    out.body[1][9, 15] = 0.8
+    out.body[2][9, 15] = 0.9
     out.body[3][9, 15] = 0.0
-    out.body[4][9, 15] = 0.1
+    out.body[4][9, 15] = 0.7
     out.body[1][11, 15] = 0.0
     out.body[2][11, 15] = 0.2
     out.body_soil[1][11, 15] = 0.2
@@ -1852,27 +1851,19 @@ end
     push!(out.body_soil_pos, [3; 12; 17])
     @test_logs (:warn, warning_message) match_mode=:any _move_intersecting_body_soil!(out)
     @test (out.body_soil[1][10, 15] == 0.6) && (out.body_soil[2][10, 15] == 0.7)
-    @test (out.body_soil[3][10, 15] == 0.3) && (out.body_soil[4][10, 15] ≈ 0.7)
+    @test (out.body_soil[3][10, 15] == 0.3) && (out.body_soil[4][10, 15] ≈ 0.5)
     @test (out.body_soil[1][11, 15] == 0.2) && (out.body_soil[2][11, 15] == 0.7)
     @test (out.body_soil[3][11, 15] == 0.8) && (out.body_soil[4][11, 15] == 0.9)
-    @test (out.body_soil[2][9, 16] == 0.3) && (out.body_soil[2][9, 16] ≈ 0.4)
+    @test (out.body_soil[1][9, 16] == 0.3) && (out.body_soil[2][9, 16] ≈ 0.4)
     @test (out.body_soil[3][9, 16] == 0.8) && (out.body_soil[4][9, 16] ≈ 0.9)
     @test (out.body_soil[3][10, 16] == 0.3) && (out.body_soil[4][10, 16] ≈ 0.5)
     @test (out.body_soil[3][11, 16] == 0.3) && (out.body_soil[4][11, 16] == 0.5)
     @test (out.body_soil[3][12, 17] == 0.3) && (out.body_soil[4][12, 17] == 0.5)
-
-    for ii in [8, 9, 10, 11, 12, 13, 14, 15]
-        for jj in [12, 13, 14, 15, 16, 17, 18, 19]
-            println(ii, " ", jj, " ", out.terrain[ii, jj])
-        end
-    end
-
     res_body_soil_pos = [
         [1; 10; 15], [3; 10; 15], [3; 11; 14], [1; 11; 15], [3; 11; 15], [3; 9; 16],
         [3; 10; 16], [3; 11; 16], [3; 12; 17], [1; 9; 16]
     ]
-    @test (out.body_soil_pos == res_body_soil_pos)
-
+    @test all(out.body_soil_pos == res_body_soil_pos)
     # Resetting values
     out.body[1][8:12, 13:17] .= 0.0
     out.body[2][8:12, 13:17] .= 0.0

--- a/test/unit_test/test_intersecting_cells.jl
+++ b/test/unit_test/test_intersecting_cells.jl
@@ -464,6 +464,7 @@ end
 end
 
 @testset "_move_intersecting_body_soil!" begin
+"""
     # Testing when soil is avalanching on the terrain (1)
     # First bucket layer at bottom
     set_RNG_seed!(1234)
@@ -1773,637 +1774,117 @@ end
     out.body_soil[3][10, 15] = 0.0
     out.body_soil[4][10, 15] = 0.0
     empty!(out.body_soil_pos)
-
-    """
-    #======================================================================================#
-    #                                                                                      #
-    #            Testing that warning is properly sent when soil cannot be moved           #
-    #                                                                                      #
-    #======================================================================================#
-    # Testing when there is the first bucket layer blocking the movement (1)
+"""
+    # Testing that warning is properly sent when soil cannot be moved
     warning_message = "Not all soil intersecting with a bucket layer could be moved\n" *
         "The extra soil has been arbitrarily removed"
-    out.body[1][9:11, 14:16] .= 0.0
-    out.body[2][9:11, 14:16] .= 0.3
-    out.body[1][10, 15] = 0.0
-    out.body[2][10, 15] = 0.1
-    out.body[3][10, 15] = 0.3
-    out.body[4][10, 15] = 0.5
-    out.body_soil[1][10, 15] = 0.1
-    out.body_soil[2][10, 15] = 0.4
-    push!(out.body_soil_pos, [1; 10; 15])
-    @test_logs (:warn, warning_message) match_mode=:any _move_intersecting_body_soil!(
-            out, grid
-        )
-    # Resetting values
-    out.body[1][9:11, 14:16] .= 0.0
-    out.body[2][9:11, 14:16] .= 0.0
+    set_RNG_seed!(1234)
+    out.body[1][10, 15] = 0.5
+    out.body[2][10, 15] = 0.6
     out.body[3][10, 15] = 0.0
-    out.body[4][10, 15] = 0.0
-    out.body_soil[1][10, 15] = 0.0
-    out.body_soil[2][10, 15] = 0.0
-    empty!(out.body_soil_pos)
-
-    # Testing when there is the first bucket layer blocking the movement (2)
-    out.body[1][9:11, 14:16] .= 0.0
-    out.body[2][9:11, 14:16] .= 0.3
-    out.body[1][10, 15] = 0.3
-    out.body[2][10, 15] = 0.5
-    out.body[3][10, 15] = 0.0
-    out.body[4][10, 15] = 0.1
-    out.body_soil[3][10, 15] = 0.1
-    out.body_soil[4][10, 15] = 0.4
-    push!(out.body_soil_pos, [3; 10; 15])
-    @test_logs (:warn, warning_message) match_mode=:any _move_intersecting_body_soil!(
-            out, grid
-        )
-    # Resetting values
-    out.body[1][9:11, 14:16] .= 0.0
-    out.body[2][9:11, 14:16] .= 0.0
-    out.body[3][10, 15] = 0.0
-    out.body[4][10, 15] = 0.0
-    out.body_soil[3][10, 15] = 0.0
-    out.body_soil[4][10, 15] = 0.0
-    empty!(out.body_soil_pos)
-
-    # Testing when there is the second bucket layer blocking the movement (1)
-    out.body[3][9:11, 14:16] .= 0.0
-    out.body[4][9:11, 14:16] .= 0.3
-    out.body[1][10, 15] = 0.0
-    out.body[2][10, 15] = 0.1
-    out.body[3][10, 15] = 0.3
-    out.body[4][10, 15] = 0.5
-    out.body_soil[1][10, 15] = 0.1
-    out.body_soil[2][10, 15] = 0.4
-    push!(out.body_soil_pos, [1; 10; 15])
-    @test_logs (:warn, warning_message) match_mode=:any _move_intersecting_body_soil!(
-            out, grid
-        )
-    # Resetting values
-    out.body[3][9:11, 14:16] .= 0.0
-    out.body[4][9:11, 14:16] .= 0.0
-    out.body[3][10, 15] = 0.0
-    out.body[4][10, 15] = 0.0
-    out.body_soil[1][10, 15] = 0.0
-    out.body_soil[2][10, 15] = 0.0
-    empty!(out.body_soil_pos)
-
-    # Testing when there is the second bucket layer blocking the movement (2)
-    out.body[3][9:11, 14:16] .= 0.0
-    out.body[4][9:11, 14:16] .= 0.3
-    out.body[1][10, 15] = 0.3
-    out.body[2][10, 15] = 0.5
-    out.body[3][10, 15] = 0.0
-    out.body[4][10, 15] = 0.1
-    out.body_soil[3][10, 15] = 0.1
-    out.body_soil[4][10, 15] = 0.4
-    push!(out.body_soil_pos, [3; 10; 15])
-    @test_logs (:warn, warning_message) match_mode=:any _move_intersecting_body_soil!(
-            out, grid
-        )
-    # Resetting values
-    out.body[3][9:11, 14:16] .= 0.0
-    out.body[4][9:11, 14:16] .= 0.0
-    out.body[3][10, 15] = 0.0
-    out.body[4][10, 15] = 0.0
-    out.body_soil[3][10, 15] = 0.0
-    out.body_soil[4][10, 15] = 0.0
-    empty!(out.body_soil_pos)
-
-    # Testing when there is the first bucket soil layer blocking the movement (1)
-    out.body[1][9:11, 14:16] .= 0.0
-    out.body[2][9:11, 14:16] .= 0.1
-    out.body_soil[1][9:11, 14:16] .= 0.1
-    out.body_soil[2][9:11, 14:16] .= 0.3
-    out.body[1][10, 15] = 0.0
-    out.body[2][10, 15] = 0.1
-    out.body[3][10, 15] = 0.3
-    out.body[4][10, 15] = 0.5
-    out.body_soil[1][10, 15] = 0.1
-    out.body_soil[2][10, 15] = 0.4
-    push!(out.body_soil_pos, [1; 10; 15])
-    @test_logs (:warn, warning_message) match_mode=:any _move_intersecting_body_soil!(
-            out, grid
-        )
-    # Resetting values
-    out.body[1][9:11, 14:16] .= 0.0
-    out.body[2][9:11, 14:16] .= 0.0
-    out.body_soil[1][9:11, 14:16] .= 0.0
-    out.body_soil[2][9:11, 14:16] .= 0.0
-    out.body[3][10, 15] = 0.0
-    out.body[4][10, 15] = 0.0
-    empty!(out.body_soil_pos)
-
-    # Testing when there is the first bucket soil layer blocking the movement (2)
-    out.body[1][9:11, 14:16] .= 0.0
-    out.body[2][9:11, 14:16] .= 0.1
-    out.body_soil[1][9:11, 14:16] .= 0.1
-    out.body_soil[2][9:11, 14:16] .= 0.3
-    out.body[1][10, 15] = 0.3
-    out.body[2][10, 15] = 0.5
-    out.body[3][10, 15] = 0.0
-    out.body[4][10, 15] = 0.1
-    out.body_soil[3][10, 15] = 0.1
-    out.body_soil[4][10, 15] = 0.4
-    push!(out.body_soil_pos, [3; 10; 15])
-    @test_logs (:warn, warning_message) match_mode=:any _move_intersecting_body_soil!(
-            out, grid
-        )
-    # Resetting values
-    out.body[1][9:11, 14:16] .= 0.0
-    out.body[2][9:11, 14:16] .= 0.0
-    out.body_soil[1][9:11, 14:16] .= 0.0
-    out.body_soil[2][9:11, 14:16] .= 0.0
-    out.body[3][10, 15] = 0.0
-    out.body[4][10, 15] = 0.0
-    out.body_soil[3][10, 15] = 0.0
-    out.body_soil[4][10, 15] = 0.0
-    empty!(out.body_soil_pos)
-
-    # Testing when there is the second bucket soil layer blocking the movement (1)
-    out.body[3][9:11, 14:16] .= 0.0
-    out.body[4][9:11, 14:16] .= 0.1
-    out.body_soil[3][9:11, 14:16] .= 0.1
-    out.body_soil[4][9:11, 14:16] .= 0.3
-    out.body[1][10, 15] = 0.0
-    out.body[2][10, 15] = 0.1
-    out.body[3][10, 15] = 0.3
-    out.body[4][10, 15] = 0.5
-    out.body_soil[1][10, 15] = 0.1
-    out.body_soil[2][10, 15] = 0.4
-    push!(out.body_soil_pos, [1; 10; 15])
-    @test_logs (:warn, warning_message) match_mode=:any _move_intersecting_body_soil!(
-            out, grid
-        )
-    # Resetting values
-    out.body[3][9:11, 14:16] .= 0.0
-    out.body[4][9:11, 14:16] .= 0.0
-    out.body_soil[3][9:11, 14:16] .= 0.0
-    out.body_soil[4][9:11, 14:16] .= 0.0
-    out.body[1][10, 15] = 0.0
-    out.body[2][10, 15] = 0.0
-    out.body_soil[1][10, 15] = 0.0
-    out.body_soil[2][10, 15] = 0.0
-    empty!(out.body_soil_pos)
-
-    # Testing when there is the second bucket soil layer blocking the movement (2)
-    out.body[3][9:11, 14:16] .= 0.0
-    out.body[4][9:11, 14:16] .= 0.1
-    out.body_soil[3][9:11, 14:16] .= 0.1
-    out.body_soil[4][9:11, 14:16] .= 0.3
-    out.body[1][10, 15] = 0.3
-    out.body[2][10, 15] = 0.5
-    out.body[3][10, 15] = 0.0
-    out.body[4][10, 15] = 0.1
-    out.body_soil[3][10, 15] = 0.1
-    out.body_soil[4][10, 15] = 0.4
-    push!(out.body_soil_pos, [3; 10; 15])
-    @test_logs (:warn, warning_message) match_mode=:any _move_intersecting_body_soil!(
-            out, grid
-        )
-    # Resetting values
-    out.body[3][9:11, 14:16] .= 0.0
-    out.body[4][9:11, 14:16] .= 0.0
-    out.body_soil[3][9:11, 14:16] .= 0.0
-    out.body_soil[4][9:11, 14:16] .= 0.0
-    out.body[1][10, 15] = 0.0
-    out.body[2][10, 15] = 0.0
-    empty!(out.body_soil_pos)
-
-    # Testing when there are two bucket layers, the first bucket layer being lower, and the
-    # second bucket layer is blocking the movement (1)
-    out.body[1][9:11, 14:16] .= -0.1
-    out.body[2][9:11, 14:16] .= 0.0
-    out.body[3][9:11, 14:16] .= 0.0
-    out.body[4][9:11, 14:16] .= 0.3
-    out.body[1][10, 15] = 0.0
-    out.body[2][10, 15] = 0.1
-    out.body[3][10, 15] = 0.3
-    out.body[4][10, 15] = 0.5
-    out.body_soil[1][10, 15] = 0.1
-    out.body_soil[2][10, 15] = 0.4
-    push!(out.body_soil_pos, [1; 10; 15])
-    @test_logs (:warn, warning_message) match_mode=:any _move_intersecting_body_soil!(
-            out, grid
-        )
-    # Resetting values
-    out.body[1][9:11, 14:16] .= 0.0
-    out.body[2][9:11, 14:16] .= 0.0
-    out.body[3][9:11, 14:16] .= 0.0
-    out.body[4][9:11, 14:16] .= 0.0
-    out.body_soil[1][10, 15] = 0.0
-    out.body_soil[2][10, 15] = 0.0
-    empty!(out.body_soil_pos)
-
-    # Testing when there are two bucket layers, the first bucket layer being lower, and the
-    # second bucket layer is blocking the movement (2)
-    out.body[1][9:11, 14:16] .= -0.1
-    out.body[2][9:11, 14:16] .= 0.0
-    out.body[3][9:11, 14:16] .= 0.0
-    out.body[4][9:11, 14:16] .= 0.3
-    out.body[1][10, 15] = 0.3
-    out.body[2][10, 15] = 0.5
-    out.body[3][10, 15] = 0.0
-    out.body[4][10, 15] = 0.1
-    out.body_soil[3][10, 15] = 0.1
-    out.body_soil[4][10, 15] = 0.4
-    push!(out.body_soil_pos, [3; 10; 15])
-    @test_logs (:warn, warning_message) match_mode=:any _move_intersecting_body_soil!(
-            out, grid
-        )
-    # Resetting values
-    out.body[1][9:11, 14:16] .= 0.0
-    out.body[2][9:11, 14:16] .= 0.0
-    out.body[3][9:11, 14:16] .= 0.0
-    out.body[4][9:11, 14:16] .= 0.0
-    out.body_soil[3][10, 15] = 0.0
-    out.body_soil[4][10, 15] = 0.0
-    empty!(out.body_soil_pos)
-
-    # Testing when there are two bucket layers, the first bucket layer being lower, and the
-    # first bucket layer is blocking the movement (1)
-    out.body[1][9:11, 14:16] .= -0.1
-    out.body[2][9:11, 14:16] .= 0.3
-    out.body[3][9:11, 14:16] .= 0.6
-    out.body[4][9:11, 14:16] .= 0.7
-    out.body[1][10, 15] = 0.0
-    out.body[2][10, 15] = 0.1
-    out.body[3][10, 15] = 0.3
-    out.body[4][10, 15] = 0.5
-    out.body_soil[1][10, 15] = 0.1
-    out.body_soil[2][10, 15] = 0.4
-    push!(out.body_soil_pos, [1; 10; 15])
-    @test_logs (:warn, warning_message) match_mode=:any _move_intersecting_body_soil!(
-            out, grid
-        )
-    # Resetting values
-    out.body[1][9:11, 14:16] .= 0.0
-    out.body[2][9:11, 14:16] .= 0.0
-    out.body[3][9:11, 14:16] .= 0.0
-    out.body[4][9:11, 14:16] .= 0.0
-    out.body_soil[1][10, 15] = 0.0
-    out.body_soil[2][10, 15] = 0.0
-    empty!(out.body_soil_pos)
-
-    # Testing when there are two bucket layers, the first bucket layer being lower, and the
-    # first bucket layer is blocking the movement (2)
-    out.body[1][9:11, 14:16] .= -0.1
-    out.body[2][9:11, 14:16] .= 0.3
-    out.body[3][9:11, 14:16] .= 0.6
-    out.body[4][9:11, 14:16] .= 0.7
-    out.body[1][10, 15] = 0.3
-    out.body[2][10, 15] = 0.5
-    out.body[3][10, 15] = 0.0
-    out.body[4][10, 15] = 0.1
-    out.body_soil[3][10, 15] = 0.1
-    out.body_soil[4][10, 15] = 0.4
-    push!(out.body_soil_pos, [3; 10; 15])
-    @test_logs (:warn, warning_message) match_mode=:any _move_intersecting_body_soil!(
-            out, grid
-        )
-    # Resetting values
-    out.body[1][9:11, 14:16] .= 0.0
-    out.body[2][9:11, 14:16] .= 0.0
-    out.body[3][9:11, 14:16] .= 0.0
-    out.body[4][9:11, 14:16] .= 0.0
-    out.body_soil[3][10, 15] = 0.0
-    out.body_soil[4][10, 15] = 0.0
-    empty!(out.body_soil_pos)
-
-    # Testing when there are two bucket layers, the second bucket layer being lower, and the
-    # first bucket layer is blocking the movement (1)
-    out.body[1][9:11, 14:16] .= 0.0
-    out.body[2][9:11, 14:16] .= 0.3
-    out.body[3][9:11, 14:16] .= -0.1
-    out.body[4][9:11, 14:16] .= 0.0
-    out.body[1][10, 15] = 0.0
-    out.body[2][10, 15] = 0.1
-    out.body[3][10, 15] = 0.3
-    out.body[4][10, 15] = 0.5
-    out.body_soil[1][10, 15] = 0.1
-    out.body_soil[2][10, 15] = 0.4
-    push!(out.body_soil_pos, [1; 10; 15])
-    @test_logs (:warn, warning_message) match_mode=:any _move_intersecting_body_soil!(
-            out, grid
-        )
-    # Resetting values
-    out.body[1][9:11, 14:16] .= 0.0
-    out.body[2][9:11, 14:16] .= 0.0
-    out.body[3][9:11, 14:16] .= 0.0
-    out.body[4][9:11, 14:16] .= 0.0
-    out.body_soil[1][10, 15] = 0.0
-    out.body_soil[2][10, 15] = 0.0
-    empty!(out.body_soil_pos)
-
-    # Testing when there are two bucket layers, the second bucket layer being lower, and the
-    # first bucket layer is blocking the movement (2)
-    out.body[1][9:11, 14:16] .= 0.0
-    out.body[2][9:11, 14:16] .= 0.3
-    out.body[3][9:11, 14:16] .= -0.1
-    out.body[4][9:11, 14:16] .= 0.0
-    out.body[1][10, 15] = 0.3
-    out.body[2][10, 15] = 0.5
-    out.body[3][10, 15] = 0.0
-    out.body[4][10, 15] = 0.1
-    out.body_soil[3][10, 15] = 0.1
-    out.body_soil[4][10, 15] = 0.4
-    push!(out.body_soil_pos, [3; 10; 15])
-    @test_logs (:warn, warning_message) match_mode=:any _move_intersecting_body_soil!(
-            out, grid
-        )
-    # Resetting values
-    out.body[1][9:11, 14:16] .= 0.0
-    out.body[2][9:11, 14:16] .= 0.0
-    out.body[3][9:11, 14:16] .= 0.0
-    out.body[4][9:11, 14:16] .= 0.0
-    out.body_soil[3][10, 15] = 0.0
-    out.body_soil[4][10, 15] = 0.0
-    empty!(out.body_soil_pos)
-
-    # Testing when there are two bucket layers, the second bucket layer being lower, and the
-    # second bucket layer is blocking the movement (1)
-    out.body[1][9:11, 14:16] .= 0.4
-    out.body[2][9:11, 14:16] .= 0.5
-    out.body[3][9:11, 14:16] .= -0.1
-    out.body[4][9:11, 14:16] .= 0.3
-    out.body[1][10, 15] = 0.0
-    out.body[2][10, 15] = 0.1
-    out.body[3][10, 15] = 0.3
-    out.body[4][10, 15] = 0.5
-    out.body_soil[1][10, 15] = 0.1
-    out.body_soil[2][10, 15] = 0.4
-    push!(out.body_soil_pos, [1; 10; 15])
-    @test_logs (:warn, warning_message) match_mode=:any _move_intersecting_body_soil!(
-            out, grid
-        )
-    # Resetting values
-    out.body[1][9:11, 14:16] .= 0.0
-    out.body[2][9:11, 14:16] .= 0.0
-    out.body[3][9:11, 14:16] .= 0.0
-    out.body[4][9:11, 14:16] .= 0.0
-    out.body_soil[1][10, 15] = 0.0
-    out.body_soil[2][10, 15] = 0.0
-    empty!(out.body_soil_pos)
-
-    # Testing when there are two bucket layers, the second bucket layer being lower, and the
-    # second bucket layer is blocking the movement (2)
-    out.body[1][9:11, 14:16] .= 0.4
-    out.body[2][9:11, 14:16] .= 0.5
-    out.body[3][9:11, 14:16] .= -0.1
-    out.body[4][9:11, 14:16] .= 0.3
-    out.body[1][10, 15] = 0.3
-    out.body[2][10, 15] = 0.5
-    out.body[3][10, 15] = 0.0
-    out.body[4][10, 15] = 0.1
-    out.body_soil[3][10, 15] = 0.1
-    out.body_soil[4][10, 15] = 0.4
-    push!(out.body_soil_pos, [3; 10; 15])
-    @test_logs (:warn, warning_message) match_mode=:any _move_intersecting_body_soil!(
-            out, grid
-        )
-    # Resetting values
-    out.body[1][9:11, 14:16] .= 0.0
-    out.body[2][9:11, 14:16] .= 0.0
-    out.body[3][9:11, 14:16] .= 0.0
-    out.body[4][9:11, 14:16] .= 0.0
-    out.body_soil[3][10, 15] = 0.0
-    out.body_soil[4][10, 15] = 0.0
-    empty!(out.body_soil_pos)
-
-    # Testing when there are two bucket layers, the first bucket layer being lower, and the
-    # bucket soil is totally filling the space (1)
-    out.body[1][9:11, 14:16] .= -0.1
-    out.body[2][9:11, 14:16] .= 0.0
-    out.body[3][9:11, 14:16] .= 0.2
-    out.body[4][9:11, 14:16] .= 0.7
-    out.body_soil[1][9:11, 14:16] .= 0.0
-    out.body_soil[2][9:11, 14:16] .= 0.2
-    out.body[1][10, 15] = 0.0
-    out.body[2][10, 15] = 0.1
-    out.body[3][10, 15] = 0.3
-    out.body[4][10, 15] = 0.5
-    out.body_soil[1][10, 15] = 0.1
-    out.body_soil[2][10, 15] = 0.4
-    push!(out.body_soil_pos, [1; 10; 15])
-    @test_logs (:warn, warning_message) match_mode=:any _move_intersecting_body_soil!(
-            out, grid
-        )
-    # Resetting values
-    out.body[1][9:11, 14:16] .= 0.0
-    out.body[2][9:11, 14:16] .= 0.0
-    out.body[3][9:11, 14:16] .= 0.0
-    out.body[4][9:11, 14:16] .= 0.0
-    out.body_soil[1][9:11, 14:16] .= 0.0
-    out.body_soil[2][9:11, 14:16] .= 0.0
-    empty!(out.body_soil_pos)
-
-    # Testing when there are two bucket layers, the first bucket layer being lower, and the
-    # bucket soil is totally filling the space (2)
-    out.body[1][9:11, 14:16] .= -0.1
-    out.body[2][9:11, 14:16] .= 0.0
-    out.body[3][9:11, 14:16] .= 0.2
-    out.body[4][9:11, 14:16] .= 0.7
-    out.body_soil[1][9:11, 14:16] .= 0.0
-    out.body_soil[2][9:11, 14:16] .= 0.2
-    out.body[1][10, 15] = 0.3
-    out.body[2][10, 15] = 0.5
-    out.body[3][10, 15] = 0.0
-    out.body[4][10, 15] = 0.1
-    out.body_soil[1][10, 15] = 0.0
-    out.body_soil[2][10, 15] = 0.0
-    out.body_soil[3][10, 15] = 0.1
-    out.body_soil[4][10, 15] = 0.4
+    out.body[4][10, 15] = 0.3
+    out.body_soil[1][10, 15] = 0.6
+    out.body_soil[2][10, 15] = 0.7
+    out.body_soil[3][10, 15] = 0.3
+    out.body_soil[4][10, 15] = 0.9
+    out.body[1][9, 14] = 0.2
+    out.body[2][9, 14] = 0.9
+    out.body[1][10, 14] = 0.0
+    out.body[2][10, 14] = 0.1
+    out.body[3][10, 14] = 0.3
+    out.body[4][10, 14] = 0.7
+    out.body[1][11, 14] = 0.8
+    out.body[2][11, 14] = 0.9
+    out.body[3][11, 14] = 0.3
+    out.body[4][11, 14] = 0.5
+    out.body[1][9, 15] = 0.2
+    out.body[2][9, 15] = 0.7
+    out.body[3][9, 15] = 0.0
+    out.body[4][9, 15] = 0.1
+    out.body[1][11, 15] = 0.0
+    out.body[2][11, 15] = 0.2
+    out.body_soil[1][11, 15] = 0.2
+    out.body_soil[2][11, 15] = 0.7
+    out.body[3][11, 15] = 0.7
+    out.body[4][11, 15] = 0.8
+    out.body_soil[3][11, 15] = 0.8
+    out.body_soil[4][11, 15] = 0.9
+    out.body[1][12, 15] = 0.0
+    out.body[2][12, 15] = 0.9
+    out.body[1][9, 16] = 0.0
+    out.body[2][9, 16] = 0.3
+    out.body[3][9, 16] = 0.4
+    out.body[4][9, 16] = 0.8
+    out.body_soil[3][9, 16] = 0.8
+    out.body_soil[4][9, 16] = 0.9
+    out.body[3][8, 17] = 0.3
+    out.body[4][8, 17] = 0.5
+    out.body[1][10, 16] = 0.5
+    out.body[2][10, 16] = 0.8
+    out.body[3][10, 16] = 0.2
+    out.body[4][10, 16] = 0.3
+    out.body_soil[3][10, 16] = 0.3
+    out.body_soil[4][10, 16] = 0.4
+    out.body[1][10, 17] = 0.3
+    out.body[2][10, 17] = 0.6
+    out.body[1][11, 16] = 0.5
+    out.body[2][11, 16] = 0.8
+    out.body[3][11, 16] = 0.2
+    out.body[4][11, 16] = 0.3
+    out.body_soil[3][11, 16] = 0.3
+    out.body_soil[4][11, 16] = 0.5
+    out.body[1][12, 17] = 0.5
+    out.body[2][12, 17] = 0.8
+    out.body[3][12, 17] = 0.2
+    out.body[4][12, 17] = 0.3
+    out.body_soil[3][12, 17] = 0.3
+    out.body_soil[4][12, 17] = 0.5
+    out.body[3][13, 18] = 0.2
+    out.body[4][13, 18] = 0.9
     push!(out.body_soil_pos, [1; 10; 15])
     push!(out.body_soil_pos, [3; 10; 15])
+    push!(out.body_soil_pos, [3; 11; 14])
+    push!(out.body_soil_pos, [1; 11; 15])
+    push!(out.body_soil_pos, [3; 11; 15])
+    push!(out.body_soil_pos, [3; 9; 16])
+    push!(out.body_soil_pos, [3; 10; 16])
+    push!(out.body_soil_pos, [3; 11; 16])
+    push!(out.body_soil_pos, [3; 12; 17])
     @test_logs (:warn, warning_message) match_mode=:any _move_intersecting_body_soil!(
             out, grid
         )
-    # Resetting values
-    out.body[1][9:11, 14:16] .= 0.0
-    out.body[2][9:11, 14:16] .= 0.0
-    out.body[3][9:11, 14:16] .= 0.0
-    out.body[4][9:11, 14:16] .= 0.0
-    out.body_soil[1][9:11, 14:16] .= 0.0
-    out.body_soil[2][9:11, 14:16] .= 0.0
-    out.body_soil[3][10, 15] = 0.0
-    out.body_soil[4][10, 15] = 0.0
-    empty!(out.body_soil_pos)
+    @test (out.body_soil[1][10, 15] == 0.6) && (out.body_soil[2][10, 15] == 0.7)
+    @test (out.body_soil[3][10, 15] == 0.3) && (out.body_soil[4][10, 15] ≈ 0.7)
+    @test (out.body_soil[1][11, 15] == 0.2) && (out.body_soil[2][11, 15] == 0.7)
+    @test (out.body_soil[3][11, 15] == 0.8) && (out.body_soil[4][11, 15] == 0.9)
+    @test (out.body_soil[2][9, 16] == 0.3) && (out.body_soil[2][9, 16] ≈ 0.4)
+    @test (out.body_soil[3][9, 16] == 0.8) && (out.body_soil[4][9, 16] ≈ 0.9)
+    @test (out.body_soil[3][10, 16] == 0.3) && (out.body_soil[4][10, 16] ≈ 0.5)
+    @test (out.body_soil[3][11, 16] == 0.3) && (out.body_soil[4][11, 16] == 0.5)
+    @test (out.body_soil[3][12, 17] == 0.3) && (out.body_soil[4][12, 17] == 0.5)
 
-    # Testing when there are two bucket layers, the second bucket layer being lower, and the
-    # bucket soil is totally filling the space (1)
-    out.body[1][9:11, 14:16] .= 0.2
-    out.body[2][9:11, 14:16] .= 0.7
-    out.body[3][9:11, 14:16] .= -0.1
-    out.body[4][9:11, 14:16] .= 0.0
-    out.body_soil[3][9:11, 14:16] .= 0.0
-    out.body_soil[4][9:11, 14:16] .= 0.2
-    out.body[1][10, 15] = 0.0
-    out.body[2][10, 15] = 0.1
-    out.body[3][10, 15] = 0.3
-    out.body[4][10, 15] = 0.5
-    out.body_soil[1][10, 15] = 0.1
-    out.body_soil[2][10, 15] = 0.4
-    out.body_soil[3][10, 15] = 0.0
-    out.body_soil[4][10, 15] = 0.0
-    push!(out.body_soil_pos, [1; 10; 15])
-    push!(out.body_soil_pos, [3; 10; 15])
-    @test_logs (:warn, warning_message) match_mode=:any _move_intersecting_body_soil!(
-            out, grid
-        )
-    # Resetting values
-    out.body[1][9:11, 14:16] .= 0.0
-    out.body[2][9:11, 14:16] .= 0.0
-    out.body[3][9:11, 14:16] .= 0.0
-    out.body[4][9:11, 14:16] .= 0.0
-    out.body_soil[3][9:11, 14:16] .= 0.0
-    out.body_soil[4][9:11, 14:16] .= 0.0
-    out.body_soil[1][10, 15] = 0.0
-    out.body_soil[2][10, 15] = 0.0
-    empty!(out.body_soil_pos)
+    for ii in [8, 9, 10, 11, 12, 13, 14, 15]
+        for jj in [12, 13, 14, 15, 16, 17, 18, 19]
+            println(ii, " ", jj, " ", out.terrain[ii, jj])
+        end
+    end
 
-    # Testing when there are two bucket layers, the second bucket layer being lower, and the
-    # bucket soil is totally filling the space (2)
-    out.body[1][9:11, 14:16] .= 0.2
-    out.body[2][9:11, 14:16] .= 0.7
-    out.body[3][9:11, 14:16] .= -0.1
-    out.body[4][9:11, 14:16] .= 0.0
-    out.body_soil[3][9:11, 14:16] .= 0.0
-    out.body_soil[4][9:11, 14:16] .= 0.2
-    out.body[1][10, 15] = 0.3
-    out.body[2][10, 15] = 0.5
-    out.body[3][10, 15] = 0.0
-    out.body[4][10, 15] = 0.1
-    out.body_soil[3][10, 15] = 0.1
-    out.body_soil[4][10, 15] = 0.4
-    push!(out.body_soil_pos, [3; 10; 15])
-    @test_logs (:warn, warning_message) match_mode=:any _move_intersecting_body_soil!(
-            out, grid
-        )
-    # Resetting values
-    out.body[1][9:11, 14:16] .= 0.0
-    out.body[2][9:11, 14:16] .= 0.0
-    out.body[3][9:11, 14:16] .= 0.0
-    out.body[4][9:11, 14:16] .= 0.0
-    out.body_soil[3][9:11, 14:16] .= 0.0
-    out.body_soil[4][9:11, 14:16] .= 0.0
-    empty!(out.body_soil_pos)
+    res_body_soil_pos = [
+        [1; 10; 15], [3; 10; 15], [3; 11; 14], [1; 11; 15], [3; 11; 15], [3; 9; 16],
+        [3; 10; 16], [3; 11; 16], [3; 12; 17], [1; 9; 16]
+    ]
+    @test (out.body_soil_pos == res_body_soil_pos)
 
-    # Testing when there are two bucket layers, the first bucket layer being lower, and the
-    # bucket soil is blocking the movement (1)
-    out.body[1][9:11, 14:16] .= -0.1
-    out.body[2][9:11, 14:16] .= 0.0
-    out.body[3][9:11, 14:16] .= 0.6
-    out.body[4][9:11, 14:16] .= 0.7
-    out.body_soil[1][9:11, 14:16] .= 0.0
-    out.body_soil[2][9:11, 14:16] .= 0.3
-    out.body[1][10, 15] = 0.0
-    out.body[2][10, 15] = 0.1
-    out.body[3][10, 15] = 0.3
-    out.body[4][10, 15] = 0.5
-    out.body_soil[1][10, 15] = 0.1
-    out.body_soil[2][10, 15] = 0.4
-    push!(out.body_soil_pos, [1; 10; 15])
-    @test_logs (:warn, warning_message) match_mode=:any _move_intersecting_body_soil!(
-            out, grid
-        )
     # Resetting values
-    out.body[1][9:11, 14:16] .= 0.0
-    out.body[2][9:11, 14:16] .= 0.0
-    out.body[3][9:11, 14:16] .= 0.0
-    out.body[4][9:11, 14:16] .= 0.0
-    out.body_soil[1][9:11, 14:16] .= 0.0
-    out.body_soil[2][9:11, 14:16] .= 0.0
+    out.body[1][8:12, 13:17] .= 0.0
+    out.body[2][8:12, 13:17] .= 0.0
+    out.body[3][8:12, 13:17] .= 0.0
+    out.body[4][8:12, 13:17] .= 0.0
+    out.body_soil[1][8:12, 13:17] .= 0.0
+    out.body_soil[2][8:12, 13:17] .= 0.0
+    out.body_soil[3][8:12, 13:17] .= 0.0
+    out.body_soil[4][8:12, 13:17] .= 0.0
+    out.body[3][13, 18] = 0.0
+    out.body[4][13, 18] = 0.0
     empty!(out.body_soil_pos)
-
-    # Testing when there are two bucket layers, the first bucket layer being lower, and the
-    # bucket soil is blocking the movement (2)
-    out.body[1][9:11, 14:16] .= -0.1
-    out.body[2][9:11, 14:16] .= 0.0
-    out.body[3][9:11, 14:16] .= 0.6
-    out.body[4][9:11, 14:16] .= 0.7
-    out.body_soil[1][9:11, 14:16] .= 0.0
-    out.body_soil[2][9:11, 14:16] .= 0.3
-    out.body[1][10, 15] = 0.3
-    out.body[2][10, 15] = 0.5
-    out.body[3][10, 15] = 0.0
-    out.body[4][10, 15] = 0.1
-    out.body_soil[1][10, 15] = 0.0
-    out.body_soil[2][10, 15] = 0.0
-    out.body_soil[3][10, 15] = 0.1
-    out.body_soil[4][10, 15] = 0.4
-    push!(out.body_soil_pos, [1; 10; 15])
-    push!(out.body_soil_pos, [3; 10; 15])
-    @test_logs (:warn, warning_message) match_mode=:any _move_intersecting_body_soil!(
-            out, grid
-        )
-    # Resetting values
-    out.body[1][9:11, 14:16] .= 0.0
-    out.body[2][9:11, 14:16] .= 0.0
-    out.body[3][9:11, 14:16] .= 0.0
-    out.body[4][9:11, 14:16] .= 0.0
-    out.body_soil[1][9:11, 14:16] .= 0.0
-    out.body_soil[2][9:11, 14:16] .= 0.0
-    out.body_soil[3][10, 15] = 0.0
-    out.body_soil[4][10, 15] = 0.0
-    empty!(out.body_soil_pos)
-
-    # Testing when there are two bucket layers, the second bucket layer being lower, and the
-    # bucket soil is blocking the movement (1)
-    out.body[1][9:11, 14:16] .= 0.6
-    out.body[2][9:11, 14:16] .= 0.7
-    out.body[3][9:11, 14:16] .= -0.1
-    out.body[4][9:11, 14:16] .= 0.0
-    out.body_soil[3][9:11, 14:16] .= 0.0
-    out.body_soil[4][9:11, 14:16] .= 0.3
-    out.body[1][10, 15] = 0.0
-    out.body[2][10, 15] = 0.1
-    out.body[3][10, 15] = 0.3
-    out.body[4][10, 15] = 0.5
-    out.body_soil[1][10, 15] = 0.1
-    out.body_soil[2][10, 15] = 0.4
-    out.body_soil[3][10, 15] = 0.0
-    out.body_soil[4][10, 15] = 0.0
-    push!(out.body_soil_pos, [1; 10; 15])
-    push!(out.body_soil_pos, [3; 10; 15])
-    @test_logs (:warn, warning_message) match_mode=:any _move_intersecting_body_soil!(
-            out, grid
-        )
-    # Resetting values
-    out.body[1][9:11, 14:16] .= 0.0
-    out.body[2][9:11, 14:16] .= 0.0
-    out.body[3][9:11, 14:16] .= 0.0
-    out.body[4][9:11, 14:16] .= 0.0
-    out.body_soil[3][9:11, 14:16] .= 0.0
-    out.body_soil[4][9:11, 14:16] .= 0.0
-    out.body_soil[1][10, 15] = 0.0
-    out.body_soil[2][10, 15] = 0.0
-    empty!(out.body_soil_pos)
-
-    # Testing when there are two bucket layers, the second bucket layer being lower, and the
-    # bucket soil is blocking the movement (2)
-    out.body[1][9:11, 14:16] .= 0.6
-    out.body[2][9:11, 14:16] .= 0.7
-    out.body[3][9:11, 14:16] .= -0.1
-    out.body[4][9:11, 14:16] .= 0.0
-    out.body_soil[3][9:11, 14:16] .= 0.0
-    out.body_soil[4][9:11, 14:16] .= 0.3
-    out.body[1][10, 15] = 0.3
-    out.body[2][10, 15] = 0.5
-    out.body[3][10, 15] = 0.0
-    out.body[4][10, 15] = 0.1
-    out.body_soil[3][10, 15] = 0.1
-    out.body_soil[4][10, 15] = 0.4
-    push!(out.body_soil_pos, [3; 10; 15])
-    @test_logs (:warn, warning_message) match_mode=:any _move_intersecting_body_soil!(
-            out, grid
-        )
-    # Resetting values
-    out.body[1][9:11, 14:16] .= 0.0
-    out.body[2][9:11, 14:16] .= 0.0
-    out.body[3][9:11, 14:16] .= 0.0
-    out.body[4][9:11, 14:16] .= 0.0
-    out.body_soil[3][9:11, 14:16] .= 0.0
-    out.body_soil[4][9:11, 14:16] .= 0.0
-    empty!(out.body_soil_pos)
-    """
 end

--- a/test/unit_test/test_intersecting_cells.jl
+++ b/test/unit_test/test_intersecting_cells.jl
@@ -24,6 +24,10 @@ out = SimOut(terrain, grid)
 #                                         Testing                                          #
 #                                                                                          #
 #==========================================================================================#
+@testset "_move_body_soil!" begin
+
+end
+
 @testset "_move_intersecting_body_soil!" begin
     # Testing when soil is avalanching on the terrain (1)
     # First bucket layer at bottom


### PR DESCRIPTION
# Description
- Removed unnecessary `grid` argument the functions in `intersecting_cells.jl`
- Now intersecting bucket soil cells are moved before intersecting terrain cell
- Improve formatting and name of variables
- Moved the core functionalities of `_move_intersecting_body_soil!` into a separate function
- Adjust unit tests for `_move_intersecting_body_soil!`
- Docstrings have been updated accordingly
- Order of functions have been updated in `intersecting_cells.jl` and the corresponding unit tests in `test_intersecting_cells.jl`

# Note
- More unit tests should be added for the `_move_intersecting_body_soil!` function
- Unit tests for the new functions should be added