### PR TITLE
Update example script

### DIFF
--- a/src/bucket.jl
+++ b/src/bucket.jl
@@ -732,24 +732,30 @@ function _calc_line_pos(
     # Avoiding issue when line is 2D
     if (dx == 0.0)
         dx = 1e-10
+    end
     if (dy == 0.0)
         dy = 1e-10
+    end
     if (dz == 0.0)
         dz = 1e-10
+    end
 
     # Determining the offset to first cell boundary
     if (step_x == 1)
         t_max_x = round(Float64, x1) + 0.5 - x1
     else
         t_max_x = x1 - round(Float64, x1) + 0.5
+    end
     if (step_y == 1)
         t_max_y = round(Float64, y1) + 0.5 - y1
     else
         t_max_y = y1 - round(Float64, y1) + 0.5
+    end
     if (step_z == 1)
         t_max_z = ceil(Float64, z1) - z1
     else
         t_max_z = z1 - floor(Float64, z1)
+    end
 
     # Determining how long on the line to cross the cell
     t_delta_x = sqrt(1.0 + (dy * dy + dz * dz) / (dx * dx))

--- a/src/relax.jl
+++ b/src/relax.jl
@@ -8,7 +8,8 @@ Copyright, 2023,  Vilella Kenny.
 #==========================================================================================#
 """
     _relax_terrain!(
-        out::SimOut{B,I,T}, grid::GridParam{I,T}, sim::SimParam{I,T}, tol::T=1e-8
+        out::SimOut{B,I,T}, grid::GridParam{I,T}, bucket::BucketParam{I,T},
+        sim::SimParam{I,T}, tol::T=1e-8
     ) where {B<:Bool,I<:Int64,T<:Float64}
 
 This function moves the soil in `terrain` towards a state closer to equilibrium.
@@ -44,6 +45,8 @@ avalanche on the bucket.
 - `out::SimOut{Bool,Int64,Float64}`: Struct that stores simulation outputs.
 - `grid::GridParam{Int64,Float64}`: Struct that stores information related to the
                                     simulation grid.
+- `bucket::BucketParam{Float64}`: Struct that stores information related to the
+                                  bucket object.
 - `sim::SimParam{Int64,Float64}`: Struct that stores information related to the
                                   simulation.
 - `tol::Float64`: Small number used to handle numerical approximation errors.
@@ -53,11 +56,16 @@ avalanche on the bucket.
 
 # Example
     grid = GridParam(4.0, 4.0, 3.0, 0.05, 0.01)
+    o = [0.0, 0.0, 0.0]
+    j = [0.0, 0.0, 0.0]
+    b = [0.0, 0.0, -0.5]
+    t = [1.0, 0.0, -0.5]
+    bucket = BucketParam(o, j, b, t, 0.5)
     sim = SimParam(0.85, 3, 4)
     terrain = zeros(2 * grid.half_length_x + 1, 2 * grid.half_length_y + 1)
     out = SimOut(terrain, grid)
 
-    _relax_terrain!(out, grid, sim)
+    _relax_terrain!(out, grid, bucket, sim)
 """
 function _relax_terrain!(
     out::SimOut{B,I,T},
@@ -145,7 +153,8 @@ end
 
 """
     _relax_body_soil!(
-        out::SimOut{B,I,T}, grid::GridParam{I,T}, sim::SimParam{I,T}, tol::T=1e-8
+        out::SimOut{B,I,T}, grid::GridParam{I,T}, bucket::BucketParam{I,T},
+        sim::SimParam{I,T}, tol::T=1e-8
     ) where {B<:Bool,I<:Int64,T<:Float64}
 
 This function moves the soil in `body_soil` towards a state closer to equilibrium.
@@ -174,6 +183,8 @@ This function only moves the soil when the following conditions are met:
 - `out::SimOut{Bool,Int64,Float64}`: Struct that stores simulation outputs.
 - `grid::GridParam{Int64,Float64}`: Struct that stores information related to the
                                     simulation grid.
+- `bucket::BucketParam{Float64}`: Struct that stores information related to the
+                                  bucket object.
 - `sim::SimParam{Int64,Float64}`: Struct that stores information related to the
                                   simulation.
 - `tol::Float64`: Small number used to handle numerical approximation errors.
@@ -183,11 +194,16 @@ This function only moves the soil when the following conditions are met:
 
 # Example
     grid = GridParam(4.0, 4.0, 3.0, 0.05, 0.01)
+    o = [0.0, 0.0, 0.0]
+    j = [0.0, 0.0, 0.0]
+    b = [0.0, 0.0, -0.5]
+    t = [1.0, 0.0, -0.5]
+    bucket = BucketParam(o, j, b, t, 0.5)
     sim = SimParam(0.85, 3, 4)
     terrain = zeros(2 * grid.half_length_x + 1, 2 * grid.half_length_y + 1)
     out = SimOut(terrain, grid)
 
-    _relax_body_soil!(out, grid, sim)
+    _relax_body_soil!(out, grid, bucket, sim)
 """
 function _relax_body_soil!(
     out::SimOut{B,I,T},
@@ -698,7 +714,7 @@ end
 """
     _relax_unstable_terrain_cell!(
         out::SimOut{B,I,T}, status::I, dh_max::T, ii::I, jj::I, ii_c::I, jj_c::I,
-        grid::GridParam{I,T}, tol::T=1e-8
+        grid::GridParam{I,T}, bucket::BucketParam{I,T}, tol::T=1e-8
     ) where {B<:Bool,I<:Int64,T<:Float64}
 
 This function moves the soil from the `terrain` at (`ii`, `jj`) to the soil column in
@@ -723,6 +739,8 @@ below the bucket to fill the space under it.
 - `jj_c::Int64`: Index of the neighboring cell in the Y direction.
 - `grid::GridParam{Int64,Float64}`: Struct that stores information related to the
                                     simulation grid.
+- `bucket::BucketParam{Float64}`: Struct that stores information related to the
+                                  bucket object.
 - `tol::Float64`: Small number used to handle numerical approximation errors.
 
 # Outputs
@@ -731,10 +749,15 @@ below the bucket to fill the space under it.
 # Example
 
     grid = GridParam(4.0, 4.0, 3.0, 0.05, 0.01)
+    o = [0.0, 0.0, 0.0]
+    j = [0.0, 0.0, 0.0]
+    b = [0.0, 0.0, -0.5]
+    t = [1.0, 0.0, -0.5]
+    bucket = BucketParam(o, j, b, t, 0.5)
     terrain = zeros(2 * grid.half_length_x + 1, 2 * grid.half_length_y + 1)
     out = SimOut(terrain, grid)
 
-    _relax_unstable_terrain_cell!(out, 131, 0.1, 10, 15, 10, 14, grid)
+    _relax_unstable_terrain_cell!(out, 131, 0.1, 10, 15, 10, 14, grid, bucket)
 """
 function _relax_unstable_terrain_cell!(
     out::SimOut{B,I,T},
@@ -916,7 +939,8 @@ end
 """
     _relax_unstable_body_cell!(
         out::SimOut{B,I,T}, status::I, new_body_soil_pos::Vector{Vector{I}}, dh_max::T,
-        ii::I, jj::I, ind::I, ii_c::I, jj_c::I, grid::GridParam{I,T}, tol::T=1e-8
+        ii::I, jj::I, ind::I, ii_c::I, jj_c::I, grid::GridParam{I,T},
+        bucket::BucketParam{I,T}, tol::T=1e-8
     ) where {B<:Bool,I<:Int64,T<:Float64}
 
 This function moves the soil from the soil layer `ind` of `body_soil` at (`ii`, `jj`) to
@@ -942,6 +966,8 @@ the `repose_angle`, provided that the bucket is not preventing this configuratio
 - `jj_c::Int64`: Index of the neighboring cell in the Y direction.
 - `grid::GridParam{Int64,Float64}`: Struct that stores information related to the
                                     simulation grid.
+- `bucket::BucketParam{Float64}`: Struct that stores information related to the
+                                  bucket object.
 - `tol::Float64`: Small number used to handle numerical approximation errors.
 
 # Outputs
@@ -951,10 +977,15 @@ the `repose_angle`, provided that the bucket is not preventing this configuratio
 
     new_body_soil_pos = Vector{Vector{Int64}}()
     grid = GridParam(4.0, 4.0, 3.0, 0.05, 0.01)
+    o = [0.0, 0.0, 0.0]
+    j = [0.0, 0.0, 0.0]
+    b = [0.0, 0.0, -0.5]
+    t = [1.0, 0.0, -0.5]
+    bucket = BucketParam(o, j, b, t, 0.5)
     terrain = zeros(2 * grid.half_length_x + 1, 2 * grid.half_length_y + 1)
     out = SimOut(terrain, grid)
 
-    _relax_unstable_body_cell!(out, 40, new_body_soil_pos, 0.1, 10, 15, 1, 10, 14, grid)
+    _relax_unstable_body_cell!(out, 40, new_body_soil_pos, 0.1, 5, 7, 1, 5, 6, grid, bucket)
 """
 function _relax_unstable_body_cell!(
     out::SimOut{B,I,T},

--- a/src/relax.jl
+++ b/src/relax.jl
@@ -299,8 +299,7 @@ could be supporting the soil column.
 - `tol::Float64`: Small number used to handle numerical approximation errors.
 
 # Outputs
-- `unstable_cells::Vector{Vector{Int64}}`: Collection of cells indices that are possibly
-                                           unstable.
+- `Vector{Vector{Int64}}`: Collection of cells indices that are possibly unstable.
 
 # Example
 
@@ -380,8 +379,8 @@ should avalanche in different scenarios.
 - `tol::Float64`: Small number used to handle numerical approximation errors.
 
 # Outputs
-- `status::Int64`: Two-digit number indicating how the soil should avalanche.
-                   `0` is returned if the soil column is stable.
+- `Int64`: Two-digit number indicating how the soil should avalanche.
+           `0` is returned if the soil column is stable.
 
 # Example
 
@@ -564,8 +563,8 @@ should avalanche in different scenarios.
 - `tol::Float64`: Small number used to handle numerical approximation errors.
 
 # Outputs
-- `status::Int64`: Two-digit number indicating how the soil should avalanche.
-                   `0` is returned if the soil column is stable.
+- `Int64`: Two-digit number indicating how the soil should avalanche.
+           `0` is returned if the soil column is stable.
 
 # Example
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -508,9 +508,9 @@ struct SimOut{B<:Bool,I<:Int64,T<:Float64}
         body_soil_pos = Vector{BodySoil{I,T}}()
 
         # Initalizing active areas
-        bucket_area = [[1 2*grid.half_length_x] [1 2*grid.half_length_y]]
-        relax_area = [[1 2*grid.half_length_x] [1 2*grid.half_length_y]]
-        impact_area = [[1 2*grid.half_length_x] [1 2*grid.half_length_y]]
+        bucket_area = Int64[[2, 2] [2 * grid.half_length_x, 2 * grid.half_length_y]]
+        relax_area = Int64[[2, 2] [2 * grid.half_length_x, 2 * grid.half_length_y]]
+        impact_area = Int64[[2, 2] [2 * grid.half_length_x, 2 * grid.half_length_y]]
 
         new{Bool,I,T}(
             [false], terrain, body, body_soil, body_soil_pos, bucket_area, relax_area,

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -8,7 +8,7 @@ Copyright, 2023,  Vilella Kenny.
 #==========================================================================================#
 """
     _calc_bucket_corner_pos(
-        pos::Vector{T}, ori::Vector{T}, bucket::BucketParam{T}
+        pos::Vector{T}, ori::Quaternion{T}, bucket::BucketParam{T}
     ) where {T<:Float64}
 
 This function calculates the global position of the six corners of the bucket.
@@ -18,7 +18,7 @@ This function calculates the global position of the six corners of the bucket.
 
 # Inputs
 - `pos::Vector{Float64}`: Cartesian coordinates of the bucket origin. [m]
-- `ori::Vector{Float64}`: Orientation of the bucket. [Quaternion]
+- `ori::Quaternion{Float64}`: Orientation of the bucket. [Quaternion]
 - `bucket::BucketParam{Float64}`: Struct that stores information related to the
                                   bucket object.
 
@@ -46,7 +46,7 @@ This function calculates the global position of the six corners of the bucket.
 """
 function _calc_bucket_corner_pos(
     pos::Vector{T},
-    ori::Vector{T},
+    ori::Quaternion{T},
     bucket::BucketParam{T}
 ) where {T<:Float64}
     # Calculating position of the bucket vertices
@@ -75,7 +75,7 @@ end
 
 """
     check_bucket_movement(
-        pos::Vector{T}, ori::Vector{T}, grid::GridParam{I,T}, bucket::BucketParam{T}
+        pos::Vector{T}, ori::Quaternion{T}, grid::GridParam{I,T}, bucket::BucketParam{T}
     ) where {I<:Int64,T<:Float64}
 
 This function calculates the maximum distance travelled by any part of the bucket since the
@@ -90,7 +90,7 @@ last soil update. The position of the bucket during the last soil update is stor
 
 # Inputs
 - `pos::Vector{Float64}`: Cartesian coordinates of the bucket origin. [m]
-- `ori::Vector{Float64}`: Orientation of the bucket. [Quaternion]
+- `ori::Quaternion{Float64}`: Orientation of the bucket. [Quaternion]
 - `grid::GridParam{Int64,Float64}`: Struct that stores information related to the
                                     simulation grid.
 - `bucket::BucketParam{Float64}`: Struct that stores information related to the
@@ -114,7 +114,7 @@ last soil update. The position of the bucket during the last soil update is stor
 """
 function check_bucket_movement(
     pos::Vector{T},
-    ori::Vector{T},
+    ori::Quaternion{T},
     grid::GridParam{I,T},
     bucket::BucketParam{T}
 ) where {I<:Int64,T<:Float64}
@@ -165,9 +165,10 @@ function check_bucket_movement(
     if (max_dist < 0.5 * min_cell_size)
         # Bucket has only slightly moved since last update
         return false
-    else if (max_dist > 2 * min_cell_size)
+    elseif (max_dist > 2 * min_cell_size)
         @warn  "Movement made by the bucket is larger than two cell size.\n"
                "The validity of the soil update is not ensured."
+    end
 
     return true
 end

--- a/test/example/soil_evolution.jl
+++ b/test/example/soil_evolution.jl
@@ -168,9 +168,6 @@ function soil_evolution(
     dt_i = dt
     time = dt
 
-    # Initializing relax_area as the full grid
-    out.relax_area[:, :] .= Int64[[2, 2] [2 * grid.half_length_x, 2 * grid.half_length_y]]
-
     # Creating time evolution
     while (time + dt_i < total_time)
        # Adding time to time vector

--- a/test/example/soil_evolution.jl
+++ b/test/example/soil_evolution.jl
@@ -79,14 +79,14 @@ function soil_evolution(
     grid_size_y = 4.0
     grid_size_z = 4.0
     cell_size_xy = 0.05
-    cell_size_z = 0.05
+    cell_size_z = 0.01
 
     # GridParam struct
     grid = GridParam(grid_size_x, grid_size_y, grid_size_z, cell_size_xy, cell_size_z)
 
     # Initializing the simulation properties
     repose_angle = 0.85
-    max_iterations = 10
+    max_iterations = 3
     cell_buffer = 4
 
     # SimParam struct
@@ -109,10 +109,10 @@ function soil_evolution(
         z_min = -0.25 + 0.5 * rand() # Between [-0.25, 0.25]
 
         # Creating the trajectory
-        pos, ori = _calc_trajectory(x_i, z_i, x_min, z_min, origin_angle, 100)
+        pos, ori = _calc_trajectory(x_i, z_i, x_min, z_min, origin_angle, 10000)
     else
         ### Default parabolic trajectory ###
-        pos, ori = _calc_trajectory(-2.0, 1.5, 0.1, 0.25, origin_angle, 100)
+        pos, ori = _calc_trajectory(-2.0, 1.5, 0.1, 0.25, origin_angle, 10000)
     end
 
     # Initializing bucket corner position vectors
@@ -202,13 +202,13 @@ function soil_evolution(
        ))
 
        # Calculating the maximum velocity of the bucket
-       max_bucket_vel = maximum([
+       max_bucket_vel = 1.25 * maximum([
            j_l_vel, j_r_vel, b_l_vel, b_r_vel, t_l_vel, t_r_vel
        ])
 
        if (max_bucket_vel != 0.0)
            ### Bucket is moving ###
-           dt_i = grid.cell_size_xy / max_bucket_vel
+           dt_i = min(grid.cell_size_xy, grid.cell_size_z) / max_bucket_vel
        else
            ### No bucket movement ###
            dt_i = dt


### PR DESCRIPTION
# Description
- Updated example script
- Updated the `soil_dynamics` functions
- Removed `step_bucket_grid` from `calc_bucket_pos`, `calc_rectangle_pos`, `calc_triangle_pos`, and `calc_line_pos` functions
- Added `bucket` and `grid` input parameters to `move_intersecting_cells`, `move_intersecting_body_soil`, and `move_body_soil` functions
- Added `bucket` input parameter to `relax_terrain`, `relax_body_soil`, `relax_unstable_terrain_cell`, and `relax_unstable_body_cell` functions
- Added `end` statement wherever required
- Debugged the `SimOut` struct
- Updated docstrings wherever required
