### PR TITLE
Bugfix: example script is not running

### DIFF
--- a/src/bucket.jl
+++ b/src/bucket.jl
@@ -656,14 +656,11 @@ end
 
 """
     _calc_line_pos(
-        a::Vector{T}, b::Vector{T}, delta::T, grid::GridParam{I,T}
+        a::Vector{T}, b::Vector{T}, grid::GridParam{I,T}
     ) where {I<:Int64,T<:Float64}
 
 This function determines all the cells that lie on a straight line between two Cartesian
 coordinates.
-
-For the sake of accuracy, the line is divided into smaller segments using a spatial
-increment `delta`.
 
 The coordinates of each sub-point (ab_i) along the line can then be calculated as
 
@@ -688,13 +685,12 @@ while `ceil` should be used for the Z direction.
 # Inputs
 - `a::Vector{Float64}`: Cartesian coordinates of the first extremity of the line. [m]
 - `b::Vector{Float64}`: Cartesian coordinates of the second extremity of the line. [m]
-- `delta::Float64`: Spatial increment used to decompose the line. [m]
 - `grid::GridParam{Int64,Float64}`: Struct that stores information related to the
                                     simulation grid.
 
 # Outputs
-- `line_pos::Vector{Vector{Int64}}`: Collection of cells indices where the line is located.
-                                     Result is not sorted and duplicates should be expected.
+- `Vector{Vector{Int64}}`: Collection of cells indices where the line is located.
+                           Result is not sorted and duplicates should be expected.
 
 # Example
 
@@ -702,12 +698,11 @@ while `ceil` should be used for the Z direction.
     a = [1.0, 0.5, 0.7]
     b = [0.7, 0.8, -0.3]
 
-    line_pos = _calc_line_pos(a, b, 0.01, grid)
+    line_pos = _calc_line_pos(a, b, grid)
 """
 function _calc_line_pos(
     a::Vector{T},
     b::Vector{T},
-    delta::T,
     grid::GridParam{I,T}
 ) where {I<:Int64,T<:Float64}
 
@@ -742,19 +737,19 @@ function _calc_line_pos(
 
     # Determining the offset to first cell boundary
     if (step_x == 1)
-        t_max_x = round(Float64, x1) + 0.5 - x1
+        t_max_x = round(x1) + 0.5 - x1
     else
-        t_max_x = x1 - round(Float64, x1) + 0.5
+        t_max_x = x1 - round(x1) + 0.5
     end
     if (step_y == 1)
-        t_max_y = round(Float64, y1) + 0.5 - y1
+        t_max_y = round(y1) + 0.5 - y1
     else
-        t_max_y = y1 - round(Float64, y1) + 0.5
+        t_max_y = y1 - round(y1) + 0.5
     end
     if (step_z == 1)
-        t_max_z = ceil(Float64, z1) - z1
+        t_max_z = ceil(z1) - z1
     else
-        t_max_z = z1 - floor(Float64, z1)
+        t_max_z = z1 - floor(z1)
     end
 
     # Determining how long on the line to cross the cell

--- a/src/intersecting_cells.jl
+++ b/src/intersecting_cells.jl
@@ -124,9 +124,9 @@ function _move_intersecting_body_soil!(
 
     # Iterating over bucket soil cells
     for nn in 1:length(out.body_soil_pos)
-        ind = out.body_soil_pos[nn][1]
-        ii = out.body_soil_pos[nn][2]
-        jj = out.body_soil_pos[nn][3]
+        ind = out.body_soil_pos[nn].ind[1]
+        ii = out.body_soil_pos[nn].ii[1]
+        jj = out.body_soil_pos[nn].jj[1]
 
         if (ind == 1)
             ### First bucket soil layer ###
@@ -149,13 +149,13 @@ function _move_intersecting_body_soil!(
             h_soil = out.body_soil[ind+1][ii, jj] - out.body[ind_t][ii, jj]
 
             # Only the intersecting soil within this body_soil_pos is moved
-            if (h_soil > out.body_soil_pos[nn][7])
+            if (h_soil > out.body_soil_pos[nn].h_soil[1])
                 ### All the soil would be moved ###
-                h_soil = out.body_soil_pos[nn][7]
-                out.body_soil_pos[nn][7] .= 0.0
+                h_soil = out.body_soil_pos[nn].h_soil[1]
+                out.body_soil_pos[nn].h_soil[1] = 0.0
             else
                 ### Soil would be partially moved ###
-                out.body_soil_pos[nn][7] -= h_soil
+                out.body_soil_pos[nn].h_soil[1] -= h_soil
             end
         else
             ### No intersection between bucket soil and bucket ###
@@ -471,10 +471,10 @@ function _move_body_soil!(
 
         # Calculating pos of cell in bucket frame
         pos = _calc_bucket_frame_pos(
-            ii_n, jj_n, out->body[4][ii_n, jj_n], grid, bucket)
+            ii_n, jj_n, out.body[4][ii_n, jj_n], grid, bucket)
 
         # Adding new bucket soil position to body_soil_pos
-        push!(out.body_soil_pos, [3; ii_n; jj_n; pos[1]; pos[2]; pos[3]; h_soil])
+        push!(out.body_soil_pos, BodySoil(3, ii_n, jj_n, pos[1], pos[2], pos[3], h_soil))
         h_soil = 0.0
     elseif (bucket_absence_3)
         ### Only the first bucket layer ###
@@ -508,10 +508,10 @@ function _move_body_soil!(
 
         # Calculating pos of cell in bucket frame
         pos = _calc_bucket_frame_pos(
-            ii_n, jj_n, out->body[2][ii_n, jj_n], grid, bucket)
+            ii_n, jj_n, out.body[2][ii_n, jj_n], grid, bucket)
 
         # Adding new bucket soil position to body_soil_pos
-        push!(out.body_soil_pos, [1; ii_n; jj_n; pos[1]; pos[2]; pos[3]; h_soil])
+        push!(out.body_soil_pos, BodySoil(1, ii_n, jj_n, pos[1], pos[2], pos[3], h_soil))
         h_soil = 0.0
     else
         ### Both bucket layers are present ###
@@ -540,7 +540,7 @@ function _move_body_soil!(
 
         # Calculating pos of cell in bucket frame
         pos = _calc_bucket_frame_pos(
-            ii_n, jj_n, out->body[ind_b_n+1][ii_n, jj_n], grid, bucket)
+            ii_n, jj_n, out.body[ind_b_n+1][ii_n, jj_n], grid, bucket)
 
         # Only option left is that there is some space for the intersecting soil
         if (bucket_soil_presence)
@@ -557,7 +557,7 @@ function _move_body_soil!(
 
                 # Adding new bucket soil position to body_soil_pos
                 push!(out.body_soil_pos,
-                    [ind_b_n; ii_n; jj_n; pos[1]; pos[2]; pos[3]; delta_h]
+                    BodySoil(ind_b_n, ii_n, jj_n, pos[1], pos[2], pos[3], delta_h)
                 )
 
                 # Updating previous position
@@ -571,7 +571,7 @@ function _move_body_soil!(
 
                 # Adding new bucket soil position to body_soil_pos
                 push!(out.body_soil_pos,
-                    [ind_b_n; ii_n; jj_n; pos[1]; pos[2]; pos[3]; h_soil]
+                    BodySoil(ind_b_n, ii_n, jj_n, pos[1], pos[2], pos[3], h_soil)
                 )
                 h_soil = 0.0
             end
@@ -592,7 +592,7 @@ function _move_body_soil!(
 
                 # Adding new bucket soil position to body_soil_pos
                 push!(out.body_soil_pos,
-                    [ind_b_n; ii_n; jj_n; pos[1]; pos[2]; pos[3]; delta_h]
+                    BodySoil(ind_b_n, ii_n, jj_n, pos[1], pos[2], pos[3], delta_h)
                 )
 
                 # Updating previous position
@@ -609,7 +609,7 @@ function _move_body_soil!(
 
                 # Adding new bucket soil position to body_soil_pos
                 push!(out.body_soil_pos,
-                    [ind_b_n; ii_n; jj_n; pos[1]; pos[2]; pos[3]; h_soil]
+                    BodySoil(ind_b_n, ii_n, jj_n, pos[1], pos[2], pos[3], h_soil)
                 )
                 h_soil = 0.0
             end

--- a/src/types.jl
+++ b/src/types.jl
@@ -379,13 +379,24 @@ This would indicate that 0.5m of soil is present on the first body layer at (10,
 which corresponds to the coordinates (0.1, 0.0, 0.2) in the reference bucket frame.
 """
 struct BodySoil{I<:Int64,T<:Float64}
-    ind::I
-    ii::I
-    jj::I
-    x_b::T
-    y_b::T
-    z_b::T
-    h_soil::T
+    ind::Vector{I}
+    ii::Vector{I}
+    jj::Vector{I}
+    x_b::Vector{T}
+    y_b::Vector{T}
+    z_b::Vector{T}
+    h_soil::Vector{T}
+    function BodySoil(
+        ind::I,
+        ii::I,
+        jj::I,
+        x_b::T,
+        y_b::T,
+        z_b::T,
+        h_soil::T
+    ) where {I<:Int64,T<:Float64}
+        new{I,T}([ind], [ii], [jj], [x_b], [y_b], [z_b], [h_soil])
+    end
 end
 
 """

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -125,7 +125,7 @@ function check_bucket_movement(
 
     # Calculating former position of bucket corners
     j_r_pos_f, j_l_pos_f, b_r_pos_f, b_l_pos_f, t_r_pos_f, t_l_pos_f = (
-        _calc_bucket_corner_pos(bucket.pos, bucket.ori, bucket)
+        _calc_bucket_corner_pos(bucket.pos, Quaternion(bucket.ori), bucket)
     )
 
     # Calculating distance travelled
@@ -160,7 +160,7 @@ function check_bucket_movement(
     )
 
     # Calculating min cell size
-    min_cell_size = min(grid.cell_size_xy_, grid.cell_size_z_)
+    min_cell_size = min(grid.cell_size_xy, grid.cell_size_z)
 
     if (max_dist < 0.5 * min_cell_size)
         # Bucket has only slightly moved since last update
@@ -221,7 +221,7 @@ function _calc_bucket_frame_pos(
     ]
 
     # Inversing rotation
-    inv_ori = [bucket.ori[1], -bucket.ori[2], -bucket.ori[3], -bucket.ori[4]]
+    inv_ori = Quaternion(bucket.ori[1], -bucket.ori[2], -bucket.ori[3], -bucket.ori[4])
 
     # Calculating reference position of cell in bucket frame
     cell_local_pos = Vector{T}(vect(inv_ori \ cell_pos * inv_ori))


### PR DESCRIPTION
# Description
- Corrected all if loop ends with an `end` statement
- Changed `SoilBody` struct to be composed of vector to be mutable
- Converted `bucket.ori` to a `Quaternion` wherever necessary
- Corrected incorrect type conversion
- Corrected initialization of variables in `_update_body_soil`
- Corrected float comparison in `_update_body_soil`
- Removed `delta` from input parameter in `bucket.jl` functions
- Corrected incorrect conversion from the cpp version